### PR TITLE
fix(Bandcamp): release credits property is nullable

### DIFF
--- a/providers/Bandcamp/json_types.ts
+++ b/providers/Bandcamp/json_types.ts
@@ -89,7 +89,7 @@ interface TrAlbumCurrent {
 	/** Description of the release. */
 	about: string;
 	/** Credits and copyright. */
-	credits: string;
+	credits: string | null;
 	auto_repriced: null;
 	new_desc_format: 1;
 	/** ID of the band (artist). */

--- a/providers/Bandcamp/mod.ts
+++ b/providers/Bandcamp/mod.ts
@@ -208,7 +208,7 @@ export class BandcampReleaseLookup extends ReleaseLookup<BandcampProvider, Album
 				types: linkTypes,
 			}],
 			images: [this.getArtwork(rawRelease.art_id, ['front'])],
-			credits: rawRelease.current.credits.replaceAll('\r', ''),
+			credits: rawRelease.current.credits?.replaceAll('\r', ''),
 			info: this.generateReleaseInfo(),
 		};
 


### PR DESCRIPTION
Found when attempting to load [this](https://acidworks.bandcamp.com/album/the-silver-weave-ep) release.