### PR TITLE
Support standalone Bandcamp tracks

### DIFF
--- a/providers/Bandcamp/json_types.ts
+++ b/providers/Bandcamp/json_types.ts
@@ -112,6 +112,8 @@ interface TrAlbumCurrent {
 	type: ReleaseType;
 	/** ID of the release. Can be `null` for standalone tracks. */
 	album_id: number | null;
+	/** ISRC of the track, for track releases. */
+	isrc?: string;
 }
 
 enum DownloadPreference {

--- a/providers/Bandcamp/json_types.ts
+++ b/providers/Bandcamp/json_types.ts
@@ -110,6 +110,8 @@ interface TrAlbumCurrent {
 	id: number;
 	/** Type of the release. */
 	type: ReleaseType;
+	/** ID of the release. Can be `null` for standalone tracks. */
+	album_id: number | null;
 }
 
 enum DownloadPreference {

--- a/providers/Bandcamp/json_types.ts
+++ b/providers/Bandcamp/json_types.ts
@@ -1,6 +1,6 @@
-export interface AlbumPage {
+export interface ReleasePage {
 	/** Information about the release. */
-	tralbum: TrAlbum;
+	tralbum: Track | Album;
 	/** Information about the band account (artist/label). */
 	band: Band;
 	/** OpenGraph description, contains the number of tracks (including hidden tracks). */
@@ -50,20 +50,35 @@ interface TrAlbum {
 	package_associated_license_id: null;
 	has_video: null;
 	tralbum_subscriber_only: boolean;
+	/** Indicates whether the release is currently available for pre-order (`null` for standalone tracks). */
+	album_is_preorder: boolean | null;
+	/** GMT date string when the release is/was released (`null` for standalone tracks). */
+	album_release_date: string | null;
+	/** Tracklist of the download release. */
+	trackinfo: TrackInfo[];
+	/** URL of the release page, might be a custom domain. */
+	url: string;
+}
+
+interface Album extends TrAlbum {
+	current: AlbumCurrent;
+	item_type: 'album';
 	featured_track_id: number;
 	initial_track_num: null;
 	/** Indicates whether the release is currently available for pre-order. */
 	is_preorder: boolean;
-	/** Same as {@linkcode is_preorder}? */
-	album_is_preorder: boolean;
-	/** GMT date string when the release is/was released. */
-	album_release_date: string;
-	/** Tracklist of the download release. */
-	trackinfo: TrackInfo[];
 	playing_from: 'album page';
-	/** URL of the release page, might be a custom domain. */
-	url: string;
 	use_expando_lyrics: boolean;
+}
+
+interface Track extends TrAlbum {
+	current: TrackCurrent;
+	item_type: 'track';
+	playing_from: 'track page';
+	/** Relative URL of the release this track is part of (`null` for standalone tracks). */
+	album_url: string | null;
+	/** Same as {@linkcode album_url}? */
+	album_upsell_url: string | null;
 }
 
 interface TrAlbumCurrent {
@@ -99,6 +114,13 @@ interface TrAlbumCurrent {
 	selling_band_id: number;
 	art_id: number;
 	download_desc_id: null;
+	/** ID of the release. */
+	id: number;
+	/** Type of the release. */
+	type: ReleaseType;
+}
+
+export interface AlbumCurrent extends TrAlbumCurrent {
 	/** GMT date string when the release is/was released. */
 	release_date: string;
 	/** UPC/EAN barcode of the download release. */
@@ -106,14 +128,25 @@ interface TrAlbumCurrent {
 	purchase_url: null;
 	purchase_title: null;
 	featured_track_id: number;
-	/** ID of the release */
-	id: number;
-	/** Type of the release. */
-	type: ReleaseType;
-	/** ID of the release. Can be `null` for standalone tracks. */
+	type: 'album';
+}
+
+export interface TrackCurrent extends TrAlbumCurrent {
+	/** Number of the track (`null` for standalone tracks). */
+	track_number: number | null;
+	release_date: null;
+	file_name: null;
+	lyrics: string | null;
+	/** ID of the release this track is part of (`null` for standalone tracks). */
 	album_id: number | null;
-	/** ISRC of the track, for track releases. */
-	isrc?: string;
+	encodings_id: number;
+	pending_encodings_id: null;
+	license_type: 1; // TODO
+	/** ISRC of the track. */
+	isrc: string | null;
+	preorder_download: null;
+	streaming: 1; // = boolean `1 | null`?
+	type: 'track';
 }
 
 enum DownloadPreference {
@@ -135,8 +168,8 @@ export interface TrackInfo {
 	encodings_id: number;
 	license_type: 1; // TODO
 	private: null;
-	/** Number of the track. */
-	track_num: number;
+	/** Number of the track (`null` for standalone tracks). */
+	track_num: number | null;
 	/** Indicates whether the release is currently available for pre-order. */
 	album_preorder: boolean;
 	/** Indicates whether the track is still unreleased. */
@@ -154,8 +187,8 @@ export interface TrackInfo {
 	free_album_download: boolean;
 	/** Duration in seconds (floating point, `0.0` for unreleased tracks). */
 	duration: number;
-	/** Always `null` on release pages, even if lyrics exist on the track page. */
-	lyrics: null;
+	/** Lyrics of the track. Always `null` on release pages, even if lyrics exist on the track page. */
+	lyrics: string | null;
 	/** Size of the lyrics (in bytes). */
 	sizeof_lyrics: number;
 	is_draft: boolean;
@@ -169,8 +202,8 @@ export interface TrackInfo {
 	alt_link: null;
 	encoding_error: null;
 	encoding_pending: null;
-	play_count: null;
-	is_capped: null;
+	play_count: number | null;
+	is_capped: boolean | null;
 	track_license_id: null;
 }
 

--- a/providers/Bandcamp/mod.ts
+++ b/providers/Bandcamp/mod.ts
@@ -153,14 +153,15 @@ export class BandcampReleaseLookup extends ReleaseLookup<BandcampProvider, Relea
 		const { tralbum: rawRelease } = albumPage;
 		const { current, packages } = rawRelease;
 
-		if (current.type === 'track' && current.album_id !== null) {
-			this.addMessage('Only standalone tracks released outside an album should be imported', 'warning');
-		}
-
 		// Main release URL might use a custom domain, fallback to URL of first package.
 		let releaseUrl = new URL(rawRelease.url);
 		if (!releaseUrl.hostname.endsWith('bandcamp.com') && packages?.length) {
 			releaseUrl = new URL(packages[0].url);
+		}
+
+		if (rawRelease.item_type === 'track' && rawRelease.album_url) {
+			const albumUrl = new URL(rawRelease.album_url, releaseUrl);
+			this.addMessage(`Please import the full release from ${albumUrl}`, 'warning');
 		}
 
 		// The "band" can be the artist or a label.

--- a/providers/Bandcamp/mod.ts
+++ b/providers/Bandcamp/mod.ts
@@ -224,6 +224,10 @@ export class BandcampReleaseLookup extends ReleaseLookup<BandcampProvider, Album
 		}
 		const tracklist = tracks.map(this.convertRawTrack.bind(this));
 
+		if (current.type === 'track' && current.isrc) {
+			tracklist[0].isrc = current.isrc;
+		}
+
 		const realTrackCount = albumPage['og:description']?.match(/(\d+) track/i)?.[1];
 		if (realTrackCount) {
 			const hiddenTrackCount = parseInt(realTrackCount) - tracks.length;

--- a/server/routes/release.tsx
+++ b/server/routes/release.tsx
@@ -18,8 +18,7 @@ import { LookupError, type ProviderError } from '@/utils/errors.ts';
 const seederTargetUrl = new URL('release/add', musicbrainzBaseUrl);
 
 export default defineRoute(async (req, ctx) => {
-	// Only set seeder URL (used for permalinks) in production servers.
-	const seederSourceUrl = ctx.config.dev ? undefined : ctx.url;
+	const seederSourceUrl = ctx.url;
 	const errors: Error[] = [];
 	let release: HarmonyRelease | undefined;
 	let enabledProviders: Set<string> | undefined = undefined;


### PR DESCRIPTION
Some `/track/` URLs on Bandcamp represent singles (often with their own cover art) that aren't otherwise released as part of an album.

It seems you can distinguish these from album tracks by checking `TrAlbumCurrent.album_id`, which is `null` for tracks without an associated album. (Perhaps there is another, more obvious way that I missed.)

In the second commit, I was able to extract an ISRC for these tracks where available. (Apparently Bandcamp only embeds ISRCs on track pages, not album pages?)

This is probably very hacky since I was still trying to wrap my head around the codebase, but I'm happy to improve it.

A few URLs I tested with:
 * [Standalone track with ISRC](https://floatingpoints.bandcamp.com/track/ratio-full-mix)
 * [Standalone track with credits, no ISRC](https://rosietucker.bandcamp.com/track/ambrosia) (note: for this example, the track is also available on an album, but the album links to a different track page, "ambrosia-2")
 * [Album track (should display a warning)](https://rosietucker.bandcamp.com/track/habanero)