### PR TITLE
fix(Bandcamp): Fall back to raw release URL for custom domains

### DIFF
--- a/providers/Bandcamp/mod.ts
+++ b/providers/Bandcamp/mod.ts
@@ -130,6 +130,8 @@ export default class BandcampProvider extends MetadataProvider {
 }
 
 export class BandcampReleaseLookup extends ReleaseLookup<BandcampProvider, ReleasePage> {
+	rawReleaseUrl: URL | undefined;
+
 	constructReleaseApiUrl(): URL | undefined {
 		return undefined;
 	}
@@ -140,6 +142,7 @@ export class BandcampReleaseLookup extends ReleaseLookup<BandcampProvider, Relea
 		}
 
 		const webUrl = this.constructReleaseUrl(this.lookup.value, this.lookup);
+		this.rawReleaseUrl = webUrl;
 		const { content: release, timestamp } = await this.provider.extractEmbeddedJson<ReleasePage>(
 			webUrl,
 			this.options.snapshotMaxTimestamp,
@@ -153,10 +156,10 @@ export class BandcampReleaseLookup extends ReleaseLookup<BandcampProvider, Relea
 		const { tralbum: rawRelease } = albumPage;
 		const { current, packages } = rawRelease;
 
-		// Main release URL might use a custom domain, fallback to URL of first package.
+		// Main release URL might use a custom domain, fallback to the cached `rawReleaseUrl`.
 		let releaseUrl = new URL(rawRelease.url);
-		if (!releaseUrl.hostname.endsWith('bandcamp.com') && packages?.length) {
-			releaseUrl = new URL(packages[0].url);
+		if (!releaseUrl.hostname.endsWith('bandcamp.com')) {
+			releaseUrl = this.rawReleaseUrl!;
 		}
 
 		if (rawRelease.item_type === 'track' && rawRelease.album_url) {


### PR DESCRIPTION
I got an error trying to import https://ponyband.bandcamp.com/track/haunted-house-remix-feat-mspaint:
```
No provider returned a release
Bandcamp: Failed to extract ID from https://ponytheband.ca/
```
The custom domain stood out to me, and I was worried I broke something related to those in #7, so I found another `/album/` with a custom domain and tested it on the `v2024.5.26` tag: https://zoekeating.bandcamp.com/album/snowmelt-ep

That gave a similar error on the `v2024.5.26` tag, so the issue isn't related to my patch.

I dug into the code to see how custom domains are handled, and found that it attempts to retrieve the actual Bandcamp URL from the `packages` array. However, neither of the releases above have any packages, so this fails.

This commit caches the raw release URL we construct in `getRawRelease` as an alternative fallback.

Questions: Is there a reason `this.rawReleaseUrl` would be incorrect in some cases? Is the `packages` fallback still needed?