### PR TITLE
Tidal provider

### DIFF
--- a/providers/Tidal/api_types.ts
+++ b/providers/Tidal/api_types.ts
@@ -1,24 +1,31 @@
-export type Artist = {
+export type SimpleArtist = {
 	/** The Tidal ID */
 	id: string;
 	name: string;
 	picture: Image[];
 	main: boolean;
-	tidalUrl: string;
 };
 
-export type Album = {
+export type Artist = SimpleArtist & {
+	tidalUrl: string;
+	popularity: number;
+};
+
+export type SimpleAlbum = {
 	/** The Tidal ID */
 	id: string;
-	barcodeId: string;
 	title: string;
-	artists: Artist[];
+	imageCover: Image[];
+	videoCover: Image[];
+};
+
+export type Album = SimpleAlbum & {
+	barcodeId: string;
+	artists: SimpleArtist[];
 	/** Full release duration in seconds */
 	duration: number;
 	/** Release date in YYYY-MM-DD format */
 	releaseDate: string;
-	imageCover: Image[];
-	videoCover: Image[];
 	numberOfVolumes: number;
 	numberOfTracks: number;
 	numberOfVideos: number;
@@ -27,24 +34,42 @@ export type Album = {
 	mediaMetadata: MediaMetadata;
 	properties: Properties;
 	tidalUrl: string;
+	providerInfo: ProviderInfo;
+	popularity: number;
 };
 
-export type AlbumItem = {
+export type CommonAlbumItem = {
 	artifactType: 'track' | 'video';
 	/** The Tidal ID */
 	id: string;
 	title: string;
-	artists: Artist[];
+	artists: SimpleArtist[];
 	/** Track duration in seconds */
 	duration: number;
+	/** Version of the album's item; complements title */
+	version: string;
+	album: SimpleAlbum;
 	trackNumber: number;
 	volumeNumber: number;
 	isrc: string;
 	copyright: string;
 	mediaMetadata: MediaMetadata;
-	properties: Properties;
 	tidalUrl: string;
+	providerInfo: ProviderInfo;
+	popularity: number;
 };
+
+export type Track = CommonAlbumItem & {
+	properties: Properties;
+};
+
+export type Video = CommonAlbumItem & {
+	properties: VideoProperties;
+	image: Image;
+	releaseDate: string;
+};
+
+export type AlbumItem = Track | Video;
 
 export type Image = {
 	url: string;
@@ -66,6 +91,16 @@ export type MediaMetadata = {
 export type Properties = {
 	/** Can be "explicit", other? */
 	content: string;
+};
+
+export type VideoProperties = Properties & {
+	/** Example: live-stream */
+	'video-type': string;
+};
+
+export type ProviderInfo = {
+	providerId: string;
+	providerName: string;
 };
 
 export type Error = {

--- a/providers/Tidal/api_types.ts
+++ b/providers/Tidal/api_types.ts
@@ -125,10 +125,3 @@ export type Result<T> = {
 	data: Resource<T>[];
 	metadata: ResultMetadata;
 };
-
-export type TokenResult = {
-	access_token: string;
-	expires_in: number;
-	scope: string;
-	token_type: string;
-};

--- a/providers/Tidal/api_types.ts
+++ b/providers/Tidal/api_types.ts
@@ -1,0 +1,92 @@
+export type Artist = {
+	/** The Tidal ID */
+	id: string;
+	name: string;
+	picture: Image[];
+	main: boolean;
+	tidalUrl: string;
+};
+
+export type Album = {
+	/** The Tidal ID */
+	id: string;
+	barcodeId: string;
+	title: string;
+	artists: Artist[];
+	/** Full release duration in seconds */
+	duration: number;
+	/** Release date in YYYY-MM-DD format */
+	releaseDate: string;
+	imageCover: Image[];
+	videoCover: Image[];
+	numberOfVolumes: number;
+	numberOfTracks: number;
+	numberOfVideos: number;
+	type: string;
+	copyright: string;
+	mediaMetadata: MediaMetadata;
+	properties: Properties;
+	tidalUrl: string;
+};
+
+export type AlbumItem = {
+	artifactType: 'track' | 'video';
+	/** The Tidal ID */
+	id: string;
+	title: string;
+	artists: Artist[];
+	/** Track duration in seconds */
+	duration: number;
+	trackNumber: number;
+	volumeNumber: number;
+	isrc: string;
+	copyright: string;
+	mediaMetadata: MediaMetadata;
+	properties: Properties;
+	tidalUrl: string;
+};
+
+export type Image = {
+	url: string;
+	width: number;
+	height: number;
+};
+
+export type Resource<T> = {
+	id: string;
+	status: number;
+	message: string;
+	resource: T;
+};
+
+export type MediaMetadata = {
+	tags: string[];
+};
+
+export type Properties = {
+	/** Can be "explicit", other? */
+	content: string;
+};
+
+export type Error = {
+	category: string;
+	code: string;
+	detail: string;
+	field: string;
+};
+
+export type ApiError = {
+	errors: Error[];
+};
+
+export type ResultMetadata = {
+	total: number;
+	requested: number;
+	success: number;
+	failure: number;
+};
+
+export type Result<T> = {
+	data: Resource<T>[];
+	metadata: ResultMetadata;
+};

--- a/providers/Tidal/api_types.ts
+++ b/providers/Tidal/api_types.ts
@@ -90,3 +90,10 @@ export type Result<T> = {
 	data: Resource<T>[];
 	metadata: ResultMetadata;
 };
+
+export type TokenResult = {
+	access_token: string;
+	expires_in: number;
+	scope: string;
+	token_type: string;
+};

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -304,16 +304,23 @@ export class TidalReleaseLookup extends ReleaseLookup<TidalProvider, Album> {
 
 	private getLargestCoverImage(images: Image[]): Artwork[] {
 		let largestImage: Image | undefined;
-		let maxSize = 0;
+		let thumbnail: Image | undefined;
 		images.forEach((i) => {
-			if (i.width > maxSize) {
+			if (!largestImage || i.width > largestImage.width) {
 				largestImage = i;
-				maxSize = i.width;
+			}
+			if (i.width >= 200 && (!thumbnail || i.width < thumbnail.width)) {
+				thumbnail = i;
 			}
 		});
 		if (!largestImage) return [];
+		let thumbUrl: URL | undefined;
+		if (thumbnail) {
+			thumbUrl = new URL(thumbnail.url);
+		}
 		return [{
 			url: new URL(largestImage.url),
+			thumbUrl: thumbUrl,
 			types: ['front'],
 		}];
 	}

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -5,7 +5,7 @@ import { parseHyphenatedDate, PartialDate } from '@/utils/date.ts';
 import { ResponseError } from '@/utils/errors.ts';
 import { encodeBase64 } from 'std/encoding/base64.ts';
 
-import type { Album, AlbumItem, ApiError, Artist, Image, Resource, Result, TokenResult } from './api_types.ts';
+import type { Album, AlbumItem, ApiError, Image, Resource, Result, SimpleArtist, TokenResult } from './api_types.ts';
 import type {
 	ArtistCreditName,
 	Artwork,
@@ -252,7 +252,7 @@ export class TidalReleaseLookup extends ReleaseLookup<TidalProvider, Album> {
 		return result;
 	}
 
-	private convertRawArtist(artist: Artist): ArtistCreditName {
+	private convertRawArtist(artist: SimpleArtist): ArtistCreditName {
 		return {
 			name: artist.name,
 			creditedName: artist.name,

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -5,7 +5,7 @@ import { parseHyphenatedDate, PartialDate } from '@/utils/date.ts';
 import { ResponseError } from '@/utils/errors.ts';
 import { encodeBase64 } from 'std/encoding/base64.ts';
 
-import type { Album, AlbumItem, ApiError, Artist, Image, Resource, Result } from './api_types.ts';
+import type { Album, AlbumItem, ApiError, Artist, Image, Resource, Result, TokenResult } from './api_types.ts';
 import type {
 	ArtistCreditName,
 	Artwork,
@@ -90,8 +90,8 @@ export default class TidalProvider extends MetadataProvider {
 		const body = new URLSearchParams();
 		body.append('grant_type', 'client_credentials');
 		body.append('client_id', tidalClientId);
-		const snapshot = await this.snaps.cache(url, {
-			fetch: this.fetch,
+
+		const cacheEntry = await this.fetchJSON<TokenResult>(url, {
 			requestInit: {
 				method: 'POST',
 				headers: {
@@ -105,8 +105,7 @@ export default class TidalProvider extends MetadataProvider {
 			},
 		});
 
-		const result = await snapshot.content.json();
-		return result.access_token;
+		return cacheEntry?.content?.access_token;
 	}
 }
 

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -129,6 +129,10 @@ export class TidalReleaseLookup extends ReleaseLookup<TidalProvider, Album> {
 	}
 
 	protected async getRawRelease(): Promise<Album> {
+		if (!this.lookup.region && this.options.regions && this.options.regions.size > 0) {
+			this.lookup.region = [...this.options.regions][0];
+		}
+
 		const apiUrl = this.constructReleaseApiUrl();
 
 		let cacheEntry, release;

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -15,6 +15,7 @@ import type {
 	HarmonyTrack,
 	Label,
 } from '@/harmonizer/types.ts';
+import { pluralWithCount } from '../../utils/plural.ts';
 
 // See https://developer.tidal.com/reference/web-api
 
@@ -218,6 +219,9 @@ export class TidalReleaseLookup extends ReleaseLookup<TidalProvider, Album> {
 			tracklist: [],
 		};
 
+		// Get info about video tracks to show a warning to the user.
+		const videoTrackInfo: string[] = [];
+
 		// split flat tracklist into media
 		tracklist.forEach((item) => {
 			// store the previous medium and create a new one
@@ -233,8 +237,21 @@ export class TidalReleaseLookup extends ReleaseLookup<TidalProvider, Album> {
 				};
 			}
 
+			if (item.artifactType === 'video') {
+				videoTrackInfo.push(`${item.trackNumber}: ${item.title}`);
+			}
+
 			medium.tracklist.push(this.convertRawTrack(item));
 		});
+
+		if (videoTrackInfo.length) {
+			this.addMessage(
+				`This release contains ${pluralWithCount(videoTrackInfo.length, 'video track')}:\n- ${
+					videoTrackInfo.join('\n- ')
+				}`,
+				'warning',
+			);
+		}
 
 		// store the final medium
 		result.push(medium);

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -35,7 +35,7 @@ export default class TidalProvider extends MetadataProvider {
 
 	readonly supportedUrls = new URLPattern({
 		hostname: '{www.}?tidal.com',
-		pathname: String.raw`/browse/:type(album|artist)/:id(\d+)`,
+		pathname: String.raw`(/browse)?/:type(album|artist)/:id(\d+)`,
 	});
 
 	readonly features: FeatureQualityMap = {
@@ -64,7 +64,7 @@ export default class TidalProvider extends MetadataProvider {
 	readonly apiBaseUrl = 'https://openapi.tidal.com';
 
 	constructUrl(entity: EntityId): URL {
-		return new URL([entity.type, entity.id].join('/'), 'https://www.tidal.com/browse/');
+		return new URL([entity.type, entity.id].join('/'), 'https://tidal.com/');
 	}
 
 	async query<Data>(apiUrl: URL, maxTimestamp?: number): Promise<CacheEntry<Data>> {

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -1,0 +1,282 @@
+import { availableRegions } from './regions.ts';
+import { type CacheEntry, MetadataProvider, type ProviderOptions, ReleaseLookup } from '@/providers/base.ts';
+import { DurationPrecision, FeatureQuality, FeatureQualityMap } from '@/providers/features.ts';
+import { parseHyphenatedDate, PartialDate } from '@/utils/date.ts';
+import { ResponseError } from '@/utils/errors.ts';
+import { encodeBase64 } from 'std/encoding/base64.ts';
+
+import type { Album, AlbumItem, ApiError, Artist, Image, Resource, Result } from './api_types.ts';
+import type {
+	ArtistCreditName,
+	Artwork,
+	EntityId,
+	HarmonyMedium,
+	HarmonyRelease,
+	HarmonyTrack,
+} from '@/harmonizer/types.ts';
+
+// See https://developer.tidal.com/reference/web-api
+
+const tidalClientId = Deno.env.get('HARMONY_TIDAL_CLIENT_ID') || '';
+const tidalClientSecret = Deno.env.get('HARMONY_TIDAL_CLIENT_SECRET') || '';
+
+export default class TidalProvider extends MetadataProvider {
+	constructor(options: ProviderOptions = {}) {
+		super({
+			rateLimitInterval: 1000,
+			concurrentRequests: 2,
+			...options,
+		});
+	}
+
+	readonly name = 'Tidal';
+
+	readonly supportedUrls = new URLPattern({
+		hostname: '{www.}?tidal.com',
+		pathname: String.raw`/browse/:type(album|artist)/:id(\d+)`,
+	});
+
+	readonly features: FeatureQualityMap = {
+		'cover size': 1280,
+		'duration precision': DurationPrecision.SECONDS,
+		'GTIN lookup': FeatureQuality.GOOD,
+		'MBID resolving': FeatureQuality.PRESENT,
+		'release label': FeatureQuality.MISSING,
+	};
+
+	readonly entityTypeMap = {
+		artist: 'artist',
+		release: 'album',
+	};
+
+	readonly availableRegions = new Set(availableRegions);
+
+	readonly releaseLookup = TidalReleaseLookup;
+
+	readonly launchDate: PartialDate = {
+		year: 2014,
+		month: 10,
+		day: 28,
+	};
+
+	readonly apiBaseUrl = 'https://openapi.tidal.com';
+
+	constructUrl(entity: EntityId): URL {
+		return new URL([entity.type, entity.id].join('/'), 'https://www.tidal.com/browse/');
+	}
+
+	async query<Data>(apiUrl: URL, maxTimestamp?: number): Promise<CacheEntry<Data>> {
+		const cacheEntry = await this.fetchJSON<Data>(apiUrl, {
+			policy: { maxTimestamp },
+			requestInit: {
+				headers: {
+					'Authorization': `Bearer ${await this.accessToken()}`,
+					'Content-Type': 'application/vnd.tidal.v1+json',
+				},
+			},
+		});
+		const { error } = cacheEntry.content as { error?: ApiError };
+
+		if (error) {
+			throw new TidalResponseError(error, apiUrl);
+		}
+		return cacheEntry;
+	}
+
+	private async accessToken(): Promise<string> {
+		// See https://developer.tidal.com/documentation/api-sdk/api-sdk-quick-start
+		const url = new URL('https://auth.tidal.com/v1/oauth2/token');
+		const auth = encodeBase64(`${tidalClientId}:${tidalClientSecret}`);
+		const body = new URLSearchParams();
+		body.append('grant_type', 'client_credentials');
+		body.append('client_id', tidalClientId);
+		const snapshot = await this.snaps.cache(url, {
+			fetch: this.fetch,
+			requestInit: {
+				method: 'POST',
+				headers: {
+					'Authorization': `Basic ${auth}`,
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body,
+			},
+			policy: {
+				maxAge: 60 * 60 * 24, // 24 hours
+			},
+		});
+
+		const result = await snapshot.content.json();
+		return result.access_token;
+	}
+}
+
+export class TidalReleaseLookup extends ReleaseLookup<TidalProvider, Album> {
+	constructReleaseApiUrl(): URL {
+		const { method, value, region } = this.lookup;
+		let lookupUrl: URL;
+		const query = new URLSearchParams({
+			countryCode: region || 'US',
+		});
+		if (method === 'gtin') {
+			lookupUrl = new URL(`/albums/byBarcodeId`, this.provider.apiBaseUrl);
+			query.append('barcodeId', value);
+		} else { // if (method === 'id')
+			lookupUrl = new URL(`albums/${value}`, this.provider.apiBaseUrl);
+		}
+
+		lookupUrl.search = query.toString();
+		return lookupUrl;
+	}
+
+	protected async getRawRelease(): Promise<Album> {
+		const apiUrl = this.constructReleaseApiUrl();
+
+		let cacheEntry, release;
+		if (this.lookup.method === 'gtin') {
+			cacheEntry = await this.provider.query<Result<Album>>(
+				apiUrl,
+				this.options.snapshotMaxTimestamp,
+			);
+
+			if (cacheEntry.content.data.length === 0) {
+				throw new ResponseError(this.provider.name, 'API returned no results for this barcode', apiUrl);
+			}
+			release = cacheEntry.content.data[0].resource;
+		} else { // if (method === 'id') {
+			cacheEntry = await this.provider.query<Resource<Album>>(
+				apiUrl,
+				this.options.snapshotMaxTimestamp,
+			);
+			release = cacheEntry.content.resource;
+		}
+
+		this.updateCacheTime(cacheEntry.timestamp);
+		return release;
+	}
+
+	private async getRawTracklist(albumId: string): Promise<AlbumItem[]> {
+		const tracklist: AlbumItem[] = [];
+		const url = new URL(`albums/${albumId}/items`, this.provider.apiBaseUrl);
+		const limit = 100;
+		let offset = 0;
+		const query = new URLSearchParams({
+			countryCode: this.lookup.region || 'US',
+			limit: String(limit),
+			offset: String(offset),
+		});
+
+		while (true) {
+			url.search = query.toString();
+			const { content, timestamp }: CacheEntry<Result<AlbumItem>> = await this.provider.query(
+				url,
+				this.options.snapshotMaxTimestamp,
+			);
+			tracklist.push(...content.data.map((r) => r.resource));
+			if (!content.metadata.total || content.metadata.total <= tracklist.length) {
+				break;
+			}
+			offset += limit;
+			query.set('offset', String(offset));
+			this.updateCacheTime(timestamp);
+		}
+
+		return tracklist;
+	}
+
+	protected async convertRawRelease(rawRelease: Album): Promise<HarmonyRelease> {
+		this.id = rawRelease.id;
+		const rawTracklist = await this.getRawTracklist(this.id);
+		const media = this.convertRawTracklist(rawTracklist);
+		return {
+			title: rawRelease.title,
+			artists: rawRelease.artists.map(this.convertRawArtist.bind(this)),
+			gtin: rawRelease.barcodeId,
+			externalLinks: [{
+				url: new URL(rawRelease.tidalUrl),
+				types: ['paid streaming'],
+			}],
+			media,
+			releaseDate: parseHyphenatedDate(rawRelease.releaseDate),
+			copyright: rawRelease.copyright,
+			status: 'Official',
+			packaging: 'None',
+			images: this.getLargestCoverImage(rawRelease.imageCover),
+			info: this.generateReleaseInfo(),
+		};
+	}
+
+	private convertRawTracklist(tracklist: AlbumItem[]): HarmonyMedium[] {
+		const result: HarmonyMedium[] = [];
+		let medium: HarmonyMedium = {
+			number: 1,
+			format: 'Digital Media',
+			tracklist: [],
+		};
+
+		// split flat tracklist into media
+		tracklist.forEach((item) => {
+			// store the previous medium and create a new one
+			if (item.volumeNumber !== medium.number) {
+				if (medium.number) {
+					result.push(medium);
+				}
+
+				medium = {
+					number: item.volumeNumber,
+					format: 'Digital Media',
+					tracklist: [],
+				};
+			}
+
+			medium.tracklist.push(this.convertRawTrack(item));
+		});
+
+		// store the final medium
+		result.push(medium);
+
+		return result;
+	}
+
+	private convertRawTrack(track: AlbumItem): HarmonyTrack {
+		const result: HarmonyTrack = {
+			number: track.trackNumber,
+			title: track.title,
+			length: track.duration * 1000,
+			isrc: track.isrc,
+			artists: track.artists.map(this.convertRawArtist.bind(this)),
+		};
+
+		return result;
+	}
+
+	private convertRawArtist(artist: Artist): ArtistCreditName {
+		return {
+			name: artist.name,
+			creditedName: artist.name,
+			externalIds: this.provider.makeExternalIds({ type: 'artist', id: artist.id.toString() }),
+		};
+	}
+
+	private getLargestCoverImage(images: Image[]): Artwork[] {
+		let largestImage: Image | undefined;
+		let maxSize = 0;
+		images.forEach((i) => {
+			if (i.width > maxSize) {
+				largestImage = i;
+				maxSize = i.width;
+			}
+		});
+		if (!largestImage) return [];
+		return [{
+			url: new URL(largestImage.url),
+			types: ['front'],
+		}];
+	}
+}
+
+class TidalResponseError extends ResponseError {
+	constructor(readonly details: ApiError, url: URL) {
+		const msg = details.errors.map((e) => `${e.field}: ${e.detail}`).join(', ');
+		super('Tidal', msg, url);
+	}
+}

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -200,12 +200,12 @@ export class TidalReleaseLookup extends ReleaseLookup<TidalProvider, Album> {
 				this.options.snapshotMaxTimestamp,
 			);
 			tracklist.push(...content.data.map((r) => r.resource));
+			this.updateCacheTime(timestamp);
 			if (!content.metadata.total || content.metadata.total <= tracklist.length) {
 				break;
 			}
 			offset += limit;
 			query.set('offset', String(offset));
-			this.updateCacheTime(timestamp);
 		}
 
 		return tracklist;

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -13,6 +13,7 @@ import type {
 	HarmonyMedium,
 	HarmonyRelease,
 	HarmonyTrack,
+	Label,
 } from '@/harmonizer/types.ts';
 
 // See https://developer.tidal.com/reference/web-api
@@ -41,7 +42,7 @@ export default class TidalProvider extends MetadataProvider {
 		'duration precision': DurationPrecision.SECONDS,
 		'GTIN lookup': FeatureQuality.GOOD,
 		'MBID resolving': FeatureQuality.PRESENT,
-		'release label': FeatureQuality.MISSING,
+		'release label': FeatureQuality.BAD,
 	};
 
 	readonly entityTypeMap = {
@@ -204,6 +205,7 @@ export class TidalReleaseLookup extends ReleaseLookup<TidalProvider, Album> {
 			status: 'Official',
 			packaging: 'None',
 			images: this.getLargestCoverImage(rawRelease.imageCover),
+			labels: this.getLabels(rawRelease),
 			info: this.generateReleaseInfo(),
 		};
 	}
@@ -274,6 +276,18 @@ export class TidalReleaseLookup extends ReleaseLookup<TidalProvider, Album> {
 			url: new URL(largestImage.url),
 			types: ['front'],
 		}];
+	}
+
+	private getLabels(rawRelease: Album): Label[] {
+		// It is unsure whether providerInfo is actually used for some releases,
+		// but it is documented in the API schemas.
+		if (rawRelease.providerInfo?.providerName) {
+			return [{
+				name: rawRelease.providerInfo?.providerName,
+			}];
+		}
+
+		return [];
 	}
 }
 

--- a/providers/Tidal/regions.ts
+++ b/providers/Tidal/regions.ts
@@ -1,0 +1,65 @@
+// Availability of Tidal: https://support.tidal.com/hc/en-us/articles/202453191-Availability-by-Country
+
+export const availableRegions = [
+	'AD', // Andorra
+	'AE', // United Arab Emirates
+	'AL', // Albania
+	'AR', // Argentina
+	'AT', // Austria
+	'AU', // Australia
+	'BA', // Bosnia and Herzegovina
+	'BE', // Belgium
+	'BG', // Bulgaria
+	'BR', // Brazil
+	'CA', // Canada
+	'CH', // Switzerland
+	'CL', // Chile
+	'CO', // Colombia
+	'CY', // Cyprus
+	'CZ', // Czech Republic
+	'DE', // Germany
+	'DK', // Denmark
+	'DM', // Dominican Republic
+	'EE', // Estonia
+	'ES', // Spain
+	'FI', // Finland
+	'FR', // France
+	'GB', // United Kingdom
+	'GR', // Greece
+	'HK', // Hong Kong
+	'HR', // Croatia
+	'HU', // Hungary
+	'IL', // Israel
+	'IR', // Ireland
+	'IS', // Iceland
+	'IT', // Italy
+	'JM', // Jamaica
+	'LI', // Liechtenstein
+	'LT', // Lithuania
+	'LU', // Luxembourg
+	'LV', // Latvia
+	'MC', // Monaco
+	'ME', // Montenegro
+	'MK', // North Macedonia
+	'MT', // Malta
+	'MX', // Mexico
+	'MY', // Malaysia
+	'NG', // Nigeria
+	'NL', // Netherlands
+	'NO', // Norway
+	'NZ', // New Zealand
+	'PE', // Peru
+	'PL', // Poland
+	'PR', // Puerto Rico
+	'PT', // Portugal
+	'RO', // Romania
+	'RS', // Serbia
+	'SE', // Sweden'
+	'SG', // Singapore
+	'SI', // Slovenia
+	'SK', // Slovakia
+	'TH', // Thailand
+	'UG', // Uganda
+	'US', // United States of America
+	'ZA', // South Africa
+];

--- a/providers/mod.ts
+++ b/providers/mod.ts
@@ -6,6 +6,7 @@ import BandcampProvider from './Bandcamp/mod.ts';
 import BeatportProvider from './Beatport/mod.ts';
 import DeezerProvider from './Deezer/mod.ts';
 import iTunesProvider from './iTunes/mod.ts';
+import TidalProvider from './Tidal/mod.ts';
 
 /** Registry with all supported providers. */
 export const providers = new ProviderRegistry();
@@ -14,6 +15,7 @@ export const providers = new ProviderRegistry();
 providers.addMultiple(
 	DeezerProvider,
 	iTunesProvider,
+	TidalProvider,
 	BandcampProvider,
 	BeatportProvider,
 );

--- a/server/components/ProviderIcon.tsx
+++ b/server/components/ProviderIcon.tsx
@@ -8,6 +8,7 @@ const providerIconMap: Record<string, string> = {
 	deezer: 'brand-deezer',
 	itunes: 'brand-apple',
 	musicbrainz: 'brand-metabrainz',
+	tidal: 'brand-tidal',
 };
 
 export type ProviderIconProps = Omit<SpriteIconProps, 'name'> & {

--- a/server/routes/icon-sprite.svg.tsx
+++ b/server/routes/icon-sprite.svg.tsx
@@ -4,6 +4,7 @@ import IconBrandApple from 'tabler-icons/brand-apple.tsx';
 import IconBrandBandcamp from 'tabler-icons/brand-bandcamp.tsx';
 import IconBrandDeezer from 'tabler-icons/brand-deezer.tsx';
 import IconBrandGit from 'tabler-icons/brand-git.tsx';
+import IconBrandTidal from 'tabler-icons/brand-tidal.tsx';
 import IconAlertTriangle from 'tabler-icons/alert-triangle.tsx';
 import IconBarcode from 'tabler-icons/barcode.tsx';
 import IconBug from 'tabler-icons/bug.tsx';
@@ -45,6 +46,7 @@ const icons: Icon[] = [
 	IconBrandDeezer,
 	IconBrandGit,
 	IconBrandMetaBrainz,
+	IconBrandTidal,
 	IconPuzzle,
 ];
 

--- a/server/static/harmony.css
+++ b/server/static/harmony.css
@@ -22,6 +22,7 @@
 	--bandcamp: #1da0c3;
 	--beatport: #00e586;
 	--deezer: #a238ff;
+	--tidal: #000000;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -366,6 +367,9 @@ label.deezer {
 }
 label.itunes {
 	background-color: var(--apple);
+}
+label.tidal {
+	background-color: var(--tidal);
 }
 
 /* ProviderIcon.tsx */


### PR DESCRIPTION
This implements a Tidal provider. The provider supports lookup by album URL or by GTIN search.

In my tests so far this working well. A few things to note:

1. For now this expects the API credentials (client ID + client secret) for the Tidal API to be set in the environment variables `HARMONY_TIDAL_CLIENT_ID` and `HARMONY_TIDAL_CLIENT_SECRET`. API credentials can be registered on the Tidal developer portal on https://developer.tidal.com/dashboard/ , see also https://developer.tidal.com/documentation/api-sdk/api-sdk-quick-start

    As discussed in chat we can add functionality to hide the provider if the pre-requisites are not given. But this is something I'd do in a separate PR. 

2. I implemented filling the label from the `providerInfo` field as documented in the API. I could however not find a release using this, it might be Tidal stopped supporting it.

3. While Tidal is available only in a limited list of markets and releases may or may not be available in specific markets (see [this list](https://support.tidal.com/hc/en-us/articles/202453191-Availability-by-Country)), the API does not indicate the availability. Instead each API request must include the country code, and the request might fail. Right now the provider tries the first given region or falls back to US.

4. Releases might contain video tracks, such as for example https://tidal.com/browse/album/130201923 . Right now those are treated like any other track. They could be filtered out, but probably shouldn't. I think in the future it would be good if Harmony would have explicit support for marking tracks as video (even if unfortunately this can currently not be seeded).

Here is a screenshot of a lookup:

![grafik](https://github.com/kellnerd/harmony/assets/29852/de9c787b-05b8-43f9-9b99-262f51f4e61a)

