### PR TITLE
Refactor per region lookup

### DIFF
--- a/providers/Deezer/mod.ts
+++ b/providers/Deezer/mod.ts
@@ -1,5 +1,5 @@
 import { availableRegions } from './regions.ts';
-import { type CacheEntry, MetadataProvider, type ProviderOptions, ReleaseLookup } from '@/providers/base.ts';
+import { type CacheEntry, MetadataApiProvider, type ProviderOptions, ReleaseApiLookup } from '@/providers/base.ts';
 import { DurationPrecision, FeatureQuality, FeatureQualityMap } from '@/providers/features.ts';
 import { parseHyphenatedDate, PartialDate } from '@/utils/date.ts';
 import { ResponseError } from '@/utils/errors.ts';
@@ -18,7 +18,7 @@ import type {
 
 // See https://developers.deezer.com/api
 
-export default class DeezerProvider extends MetadataProvider {
+export default class DeezerProvider extends MetadataApiProvider {
 	constructor(options: ProviderOptions = {}) {
 		super({
 			rateLimitInterval: 5000,
@@ -75,7 +75,7 @@ export default class DeezerProvider extends MetadataProvider {
 	}
 }
 
-export class DeezerReleaseLookup extends ReleaseLookup<DeezerProvider, Release> {
+export class DeezerReleaseLookup extends ReleaseApiLookup<DeezerProvider, Release> {
 	constructor(provider: DeezerProvider, specifier: ReleaseSpecifier, options: ReleaseOptions = {}) {
 		super(provider, specifier, options);
 

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -146,21 +146,21 @@ export class TidalReleaseLookup extends ReleaseApiLookup<TidalProvider, Album> {
 			this.options.regions = new Set([this.provider.defaultRegion]);
 		}
 		if (this.lookup.method === 'gtin') {
-			const validator = (data: Result<Album>) => {
+			const isValidData = (data: Result<Album>) => {
 				return Boolean(data?.data?.length);
 			};
-			const result = await this.queryAllRegions<Result<Album>>(validator);
+			const result = await this.queryAllRegions<Result<Album>>(isValidData);
 			return result.data[0].resource;
 		} else {
-			const validator = (data: Resource<Album>) => {
+			const isValidData = (data: Resource<Album>) => {
 				return Boolean(data?.resource);
 			};
 			// If this was a 404 not found error, ignore it and try next region.
-			const errorValidator = (error: unknown) => {
+			const isCriticalError = (error: unknown) => {
 				const { response } = error as { response?: Response };
-				return response?.status === 404;
+				return response?.status !== 404;
 			};
-			const result = await this.queryAllRegions<Resource<Album>>(validator, errorValidator);
+			const result = await this.queryAllRegions<Resource<Album>>(isValidData, isCriticalError);
 			return result.resource;
 		}
 	}

--- a/providers/base.ts
+++ b/providers/base.ts
@@ -401,6 +401,4 @@ export type CacheEntry<Content> = {
 	timestamp: number;
 	/** Indicates that the cache entry has been created by the returning method. */
 	isFresh: boolean;
-	/** Successfully queried region of the API. */
-	region?: CountryCode;
 };

--- a/providers/base.ts
+++ b/providers/base.ts
@@ -365,8 +365,8 @@ export abstract class ReleaseApiLookup<Provider extends MetadataApiProvider, Raw
 
 	/** Performs the query for the URL returned by {@linkcode constructReleaseApiUrl} for all configured regions until valid data is returned. */
 	protected async queryAllRegions<Data>(
-		dataValidator: (data: Data) => boolean,
-		errorValidator: (error: unknown) => boolean = (_) => false,
+		isValidData: (data: Data) => boolean,
+		isCriticalError: (error: unknown) => boolean = (_) => true,
 	): Promise<Data> {
 		for (const region of this.options.regions || []) {
 			this.lookup.region = region;
@@ -376,13 +376,13 @@ export abstract class ReleaseApiLookup<Provider extends MetadataApiProvider, Raw
 					apiUrl,
 					this.options.snapshotMaxTimestamp,
 				);
-				if (dataValidator(cacheEntry.content)) {
+				if (isValidData(cacheEntry.content)) {
 					this.updateCacheTime(cacheEntry.timestamp);
 					return cacheEntry.content;
 				}
 			} catch (error: unknown) {
 				// Allow the caller to ignore exceptions and retry next region.
-				if (!errorValidator(error)) {
+				if (isCriticalError(error)) {
 					throw error;
 				}
 			}

--- a/providers/iTunes/mod.ts
+++ b/providers/iTunes/mod.ts
@@ -103,10 +103,10 @@ export class iTunesReleaseLookup extends ReleaseApiLookup<iTunesProvider, Releas
 		if (!this.options.regions?.size) {
 			this.options.regions = new Set([this.provider.defaultRegion]);
 		}
-		const validator = (data: ReleaseResult) => {
+		const isValidData = (data: ReleaseResult) => {
 			return Boolean(data?.resultCount);
 		};
-		return await this.queryAllRegions<ReleaseResult>(validator);
+		return await this.queryAllRegions<ReleaseResult>(isValidData);
 	}
 
 	protected convertRawRelease(data: ReleaseResult): HarmonyRelease {


### PR DESCRIPTION
This refactors the multi-region lookups in Tidal and iTunes to use a common abstraction.

It implements abstract base classes `MetadataApiProvider` and `ReleaseApiLookup` as specializations of the existing abstract classes that hold functionality common to typical API based providers. 

`MetadataApiProvider`  for now only enforces the implementation of a `query` function as we already had it on the Deezer, iTunes and Tidal providers. `ReleaseApiLookup` provides the helper method `queryAllRegions` which generalizes performing release queries for each region until a result is found.

`queryAllRegions` expects a validator callback, which must verify the request response. If the result is usable the validator must return true. If it returns false the next region is tried. There is a optional error validator which can be used to validate exceptions being thrown during query.

Overall this greatly simplifies the request handling in both the iTunes and Deezer provider.

The new base classes will also be suited for adding abstractions for e.g. access token handling a currently present in the Tidal provider.