### PR TITLE
fix(web): do not fail parsing country codes with surrounding spaces

### DIFF
--- a/server/state.ts
+++ b/server/state.ts
@@ -62,7 +62,7 @@ export function extractReleaseLookupState(lookupUrl: URL): ReleaseLookupParamete
 
 	// Also accept comma-separated regions from HTML form for convenience.
 	let regions = searchParams.getAll('region').filter(isNotEmpty)
-		.flatMap((value) => value.toUpperCase().split(','));
+		.flatMap((value) => value.toUpperCase().split(',').map((s) => s.trim()));
 	if (!regions.length) {
 		regions = defaultRegions;
 	}


### PR DESCRIPTION
If as a user you entered "GB, US" instead of "GB,US" this caused an error "' US' is not a valid ISO 3166-1 alpha-2 country code with two letters".

Be more tolerant with the input and trim the values after splitting by comma.