### PR TITLE
feat(Bandcamp): set creative commons license URL if available

### DIFF
--- a/harmonizer/types.ts
+++ b/harmonizer/types.ts
@@ -108,7 +108,8 @@ export type LinkType =
 	| 'free streaming'
 	| 'mail order'
 	| 'paid download'
-	| 'paid streaming';
+	| 'paid streaming'
+	| 'license';
 
 /** MusicBrainz medium formats (incomplete). */
 export type MediumFormat =

--- a/musicbrainz/seeding.ts
+++ b/musicbrainz/seeding.ts
@@ -110,6 +110,8 @@ function convertLinkType(linkType: LinkType, url?: URL): UrlLinkTypeId | undefin
 		case 'discography page':
 			// TODO: handle special cases based on their URLs
 			return urlTypeIds['discography entry'];
+		case 'license':
+			return urlTypeIds['license'];
 	}
 }
 

--- a/providers/Bandcamp/json_types.ts
+++ b/providers/Bandcamp/json_types.ts
@@ -5,6 +5,8 @@ export interface ReleasePage {
 	band: Band;
 	/** OpenGraph description, contains the number of tracks (including hidden tracks). */
 	'og:description'?: string;
+	/** License URL. */
+	licenseUrl?: string;
 }
 
 interface Band {


### PR DESCRIPTION
This extracts Creative Common license URLs from Bandcamp pages and submits them as license URL link to MB.

This also generally completes the support for external links of type "license". Fixes #19

Some examples for testing:

- https://aeonsable.bandcamp.com/album/aenigma-2023
- https://aneagleinyourmind.bandcamp.com/album/intersection
- https://deusexlumina.bandcamp.com/track/my-church-is-black-me-and-that-man
- https://binaerpilot.bandcamp.com/album/songs-for-alan-turing