### PR TITLE
fix(Tidal): fixed request error detection

### DIFF
--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -89,7 +89,7 @@ export default class TidalProvider extends MetadataApiProvider {
 			});
 			const apiError = cacheEntry.content as ApiError;
 
-			if (apiError) {
+			if (apiError?.errors) {
 				throw new TidalResponseError(apiError, apiUrl);
 			}
 			return cacheEntry;


### PR DESCRIPTION
This is a small fix for 6124885c41858e49b9e47f3acd5aa313856bacdb . The error handling detected all (non-empty) responses as error. Actually check for the `errors` attribute.