### PR TITLE
feat(docker): Add option to run via Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM denoland/deno
+
+EXPOSE 8000
+
+WORKDIR /app
+
+ADD . /app
+
+RUN deno cache server/main.ts
+
+ARG version
+ENV DENO_DEPLOYMENT_ID $version
+CMD deno run -A server/main.ts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  web:
+    build:
+      context: .
+      args:
+        version: v2024.6.12
+    container_name: harmony-container
+    image: harmony
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
I know this isn't necessarily a needed option at this point, but I thought I'd try my hand at Dockerizing this project in the interest of making it able to run on more platforms. Open to any questions, suggestions, or concerns you might have!

The Dockerfile and Compose spec included in this draft are relatively basic at this point; for one thing, the choice of version to run currently has to be manually specified in the Dockerfile. However, if further development is desired, it may be possible to work around this while developing a more formal build workflow through GitHub Actions or the like.