### PR TITLE
feat(Tidal): format textual copyright symbols as © or ℗

### DIFF
--- a/providers/Spotify/mod.ts
+++ b/providers/Spotify/mod.ts
@@ -2,9 +2,10 @@ import { ApiAccessToken, type CacheEntry, MetadataApiProvider, ReleaseApiLookup 
 import { DurationPrecision, FeatureQuality, FeatureQualityMap } from '@/providers/features.ts';
 import { capitalizeReleaseType } from '@/harmonizer/release_types.ts';
 import { parseHyphenatedDate, PartialDate } from '@/utils/date.ts';
-import { splitLabels } from '@/utils/label.ts';
+import { formatCopyrightSymbols } from '@/utils/copyright.ts';
 import { ResponseError } from '@/utils/errors.ts';
 import { selectLargestImage } from '@/utils/image.ts';
+import { splitLabels } from '@/utils/label.ts';
 import { encodeBase64 } from 'std/encoding/base64.ts';
 import { availableRegions } from './regions.ts';
 
@@ -342,12 +343,8 @@ export class SpotifyReleaseLookup extends ReleaseApiLookup<SpotifyProvider, Albu
 		// copyright those get often entered without the corresponding symbol.
 		// When only importing the text entry the information gets lost. Hence
 		// prefix the entries with the © or ℗ symbol if it is not already present.
-		let { text, type } = copyright;
-		text = text.replace(/\(c\)/i, '©').replace(/\(p\)/i, '℗');
-		if (!text.includes('©') && !text.includes('℗')) {
-			text = `${type === 'P' ? '℗' : '©'} ${text}`;
-		}
-		return text;
+		const symbol = copyright.type === 'P' ? '℗' : '©';
+		return formatCopyrightSymbols(copyright.text, symbol);
 	}
 }
 

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -8,6 +8,7 @@ import {
 } from '@/providers/base.ts';
 import { DurationPrecision, FeatureQuality, FeatureQualityMap } from '@/providers/features.ts';
 import { capitalizeReleaseType } from '@/harmonizer/release_types.ts';
+import { formatCopyrightSymbols } from '@/utils/copyright.ts';
 import { parseHyphenatedDate, PartialDate } from '@/utils/date.ts';
 import { ResponseError } from '@/utils/errors.ts';
 import { selectLargestImage } from '@/utils/image.ts';
@@ -220,7 +221,7 @@ export class TidalReleaseLookup extends ReleaseApiLookup<TidalProvider, Album> {
 			}],
 			media,
 			releaseDate: parseHyphenatedDate(rawRelease.releaseDate),
-			copyright: rawRelease.copyright,
+			copyright: formatCopyrightSymbols(rawRelease.copyright),
 			status: 'Official',
 			types: [capitalizeReleaseType(rawRelease.type)],
 			packaging: 'None',

--- a/utils/copyright.test.ts
+++ b/utils/copyright.test.ts
@@ -1,0 +1,30 @@
+import { formatCopyrightSymbols } from './copyright.ts';
+
+import { assertEquals } from 'std/assert/assert_equals.ts';
+import { describe, it } from 'std/testing/bdd.ts';
+
+import type { FunctionSpec } from './test_spec.ts';
+
+describe('format copyright symbols', () => {
+	const passingCases: FunctionSpec<typeof formatCopyrightSymbols> = [
+		['should keep string without symbols', 'Nuclear Blast', undefined, 'Nuclear Blast'],
+		['should replace (P)', '(P) 2016 Century Media Records Ltd.', undefined, '℗ 2016 Century Media Records Ltd.'],
+		['should keep symbols', '© 2012 S. Carter Enterprises, LLC.', undefined, '© 2012 S. Carter Enterprises, LLC.'],
+		[
+			'should convert multiple symbols',
+			'(p)(c) 2017 S. CARTER ENTERPRISES, LLC. MARKETED BY ROC NATION & DISTRIBUTED BY ROC NATION/UMG RECORDINGS INC.',
+			undefined,
+			'℗© 2017 S. CARTER ENTERPRISES, LLC. MARKETED BY ROC NATION & DISTRIBUTED BY ROC NATION/UMG RECORDINGS INC.',
+		],
+		['should prepend expected symbol', 'Nuclear Blast', '℗', '℗ Nuclear Blast'],
+		['should not prepend symbol if it exists', '2024 ℗ Nuclear Blast', '℗', '2024 ℗ Nuclear Blast'],
+		['should not prepend symbol if any exists', '2024 © Nuclear Blast', '℗', '2024 © Nuclear Blast'],
+		['should not prepend symbol if it exists as text', '(c)+(p) Nuclear Blast', '℗', '©+℗ Nuclear Blast'],
+	];
+
+	passingCases.forEach(([description, copyright, expectedSymbol, expected]) => {
+		it(description, () => {
+			assertEquals(formatCopyrightSymbols(copyright, expectedSymbol), expected);
+		});
+	});
+});

--- a/utils/copyright.ts
+++ b/utils/copyright.ts
@@ -1,0 +1,12 @@
+/** Formats a copyright string, replacing (c) and (p) with the corresponding symbol.
+ *
+ * If expectedSymbol is given the symbol will be prepended if no other copyright symbol
+ * is already present in the string.
+ */
+export function formatCopyrightSymbols(copyright: string, expectedSymbol: '©' | '℗' | undefined = undefined): string {
+	copyright = copyright.replace(/\(c\)/i, '©').replace(/\(p\)/i, '℗');
+	if (expectedSymbol && !copyright.includes('©') && !copyright.includes('℗')) {
+		copyright = `${expectedSymbol} ${copyright}`;
+	}
+	return copyright;
+}


### PR DESCRIPTION
On Tidal it s very common to have copyright symbols in textual form, e.g. "(p)" or "(C)", instead of the dedicated symbols ℗ or ©. The symbols are also used, but it is not mandatory.

Add a utility function `formatCopyrightSymbols` to handle this. Also use this function in the existing Spotify implementation for copyright cleanup.

This PR partially but not completely addresses #23. I wanted to fix the most prominent issue where Tidal shows "(p) 2024 Some Band", but Spotify and iTunes give "℗ 2024 Some Band". Now there is a single consistent copyright entry.

Previously for https://tidal.com/album/64944658:
![grafik](https://github.com/kellnerd/harmony/assets/29852/af5739ce-75fd-4f6d-8a91-996589f4e84f)

Now:
![grafik](https://github.com/kellnerd/harmony/assets/29852/31ea2d48-08d5-431e-a540-4898e67acb5f)

What this PR does not address:

- Handling copyright entries on Tidal without any symbol at all (textual or not). This needs more consideration, see my comment https://github.com/kellnerd/harmony/issues/23#issuecomment-2157983729
- Considering Tidal copyright entries on track level
- Considering any other provider (but only ones with copyright right now are iTunes and Spotify, and those seem to be fine)