### PR TITLE
feat(Tidal): Show a warning if API returns not all tracks for the release

### DIFF
--- a/providers/Tidal/v2/lookup.ts
+++ b/providers/Tidal/v2/lookup.ts
@@ -125,6 +125,14 @@ export class TidalV2ReleaseLookup extends ReleaseApiLookup<TidalProvider, Single
 			next = content.links.next;
 		}
 
+		const realTrackCount = rawRelease.data.attributes.numberOfItems;
+		if (items.length < realTrackCount) {
+			this.addMessage(
+				`The API returned only ${items.length} of ${realTrackCount} tracks for ${this.lookup.region}, other regions may have more`,
+				'warning',
+			);
+		}
+
 		const result: HarmonyMedium[] = [];
 		let medium: HarmonyMedium = {
 			number: 1,


### PR DESCRIPTION
Show a warning if Tidal returns not all tracks for a release. The `numberOfItems` attribute will still hold the correct track count, but depending on region Tidal might not return all tracks.

See also #65. Not sure if this PR can be considered a full solution, butt it definitely helps to handle this situation.

E.g. if you query https://tidal.com/album/4670631 with region set to GB or US than only 10 of 15 tracks are returned. With region set to DE or FR it returns even only 6 of 15 tracks.

![Screenshot 2025-02-20 at 22-00-42 Greatest Hits – Harmony](https://github.com/user-attachments/assets/b11d1b6f-3809-4bb8-8cb1-017af277f423)
