### PR TITLE
feat(Tidal): Support loading video releases

### DIFF
--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -42,7 +42,7 @@ export default class TidalProvider extends MetadataApiProvider {
 
 	readonly supportedUrls = new URLPattern({
 		hostname: '{(www|listen).}?tidal.com',
-		pathname: String.raw`{/browse}?/:type(album|artist)/:id(\d+)`,
+		pathname: String.raw`{/browse}?/:type(album|artist|video)/:id(\d+)`,
 	});
 
 	override readonly features: FeatureQualityMap = {
@@ -55,7 +55,7 @@ export default class TidalProvider extends MetadataApiProvider {
 
 	readonly entityTypeMap = {
 		artist: 'artist',
-		release: 'album',
+		release: ['album', 'video'],
 	};
 
 	readonly defaultRegion: CountryCode = 'US';

--- a/providers/Tidal/mod.ts
+++ b/providers/Tidal/mod.ts
@@ -80,8 +80,17 @@ export default class TidalProvider extends MetadataApiProvider {
 		return super.getRelease(specifier, options);
 	}
 
+	override extractEntityFromUrl(url: URL): EntityId | undefined {
+		const entity = super.extractEntityFromUrl(url);
+		// Encode 'video' type into the ID to distinguish them from 'album' releases.
+		if (entity?.type === 'video') {
+			entity.id = [entity.type, entity.id].join('/');
+		}
+		return entity;
+	}
+
 	constructUrl(entity: EntityId): URL {
-		return join('https://tidal.com', entity.type, entity.id);
+		return join('https://tidal.com', entity.id.startsWith('video/') ? '' : entity.type, entity.id);
 	}
 
 	override getLinkTypesForEntity(): LinkType[] {

--- a/providers/base.ts
+++ b/providers/base.ts
@@ -238,6 +238,7 @@ export abstract class ReleaseLookup<Provider extends MetadataProvider, RawReleas
 				throw new ProviderError(this.provider.name, `${specifier} is not a release URL`);
 			}
 			this.id = entity.id;
+			this.entity = entity;
 			this.lookup = { method: 'id', value: entity.id };
 
 			// Prefer region of the given release URL over the standard preferences.
@@ -267,6 +268,9 @@ export abstract class ReleaseLookup<Provider extends MetadataProvider, RawReleas
 	/** Date and time when the (last piece of) provider data was cached (in seconds since the UNIX epoch). */
 	private cacheTime: number | undefined;
 
+	/** Provider entity of the currently looked up release (initially undefined). */
+	protected entity: EntityId | undefined;
+
 	/** Updates {@linkcode cacheTime}, should be called after every cached request. */
 	protected updateCacheTime(timestamp: number) {
 		if (!this.cacheTime || timestamp > this.cacheTime) {
@@ -280,7 +284,7 @@ export abstract class ReleaseLookup<Provider extends MetadataProvider, RawReleas
 	 * This is implemented using {@linkcode MetadataProvider.constructUrl} by default.
 	 */
 	constructReleaseUrl(id: string, lookup: ReleaseLookupParameters): URL {
-		let type = this.provider.entityTypeMap['release'];
+		let type = this.entity?.type || this.provider.entityTypeMap['release'];
 		if (Array.isArray(type)) {
 			// Use the first mapped type as the default `release` type of the provider.
 			// This should mean the actual type is encoded in the ID, but we'll default to this if not.


### PR DESCRIPTION
This adds support for loading video releases from Tidal, such as 

- https://tidal.com/browse/video/358461354
- https://tidal.com/browse/video/166459496

The releases get treated as singles. Video singles on Tidal have release dates and labels, but don't have GTIN.

This fixes #26 
