### PR TITLE
parseGermanDate() fixed that it also finds “March”

### DIFF
--- a/providers/Hoerspielforscher/mapping.ts
+++ b/providers/Hoerspielforscher/mapping.ts
@@ -3,6 +3,7 @@ import type { MediumFormat } from '@/harmonizer/types.ts';
 export const mediumFormatMap: Record<string, MediumFormat | undefined> = {
 	'Audio CD': 'CD',
 	'Audio-CD': 'CD',
+	'Audio-Dateien': 'Digital Media',
 	'12"-Vinyl, 33 1/3 rpm': '12" Vinyl',
 	'Musik-Cassette': 'Cassette',
 };

--- a/providers/mod.ts
+++ b/providers/mod.ts
@@ -5,6 +5,7 @@ import type { ProviderPreferences } from '@/harmonizer/types.ts';
 import BandcampProvider from './Bandcamp/mod.ts';
 import BeatportProvider from './Beatport/mod.ts';
 import DeezerProvider from './Deezer/mod.ts';
+import HörspielforscherProvider from './Hoerspielforscher/mod.ts';
 import iTunesProvider from './iTunes/mod.ts';
 import MusicBrainzProvider from './MusicBrainz/mod.ts';
 import SpotifyProvider from './Spotify/mod.ts';
@@ -24,6 +25,7 @@ providers.addMultiple(
 	TidalProvider,
 	BandcampProvider,
 	BeatportProvider,
+	HörspielforscherProvider,
 );
 
 /** Internal names of providers which are enabled by default (for GTIN lookups). */

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -24,7 +24,7 @@ export function formatPartialDate(date: PartialDate) {
 
 /** Parses a German date with the month given as a string. */
 export function parseGermanDate(date: string): PartialDate | undefined {
-	const dateMatch = date.match(/^(?:(\d{1,2})\. )?(?:(\w+) )?(\d{4})$/);
+	const dateMatch = date.match(/^(?:(\d{1,2})\. )?(?:([\u00E4\w]+) )?(\d{4})$/);
 	if (!dateMatch) return;
 
 	const [_, day, monthName, year] = dateMatch;


### PR DESCRIPTION
\w does not capture German umlauts. Unicode for ä added to the pattern so that 'März' is also found.