### PR TITLE
feat: populate track relationship types for Bandcamp

### DIFF
--- a/harmonizer/types.ts
+++ b/harmonizer/types.ts
@@ -30,6 +30,8 @@ export interface EntityId {
 export interface ExternalEntityId extends EntityId {
 	/** Internal name of the provider. */
 	provider: string;
+	/** Optional link types for this external ID. */
+	linkTypes?: LinkType[];
 }
 
 /** Entity which may have external IDs which can be resolved to its MBID. */

--- a/providers/Bandcamp/__snapshots__/mod.test.ts.snap
+++ b/providers/Bandcamp/__snapshots__/mod.test.ts.snap
@@ -74,6 +74,10 @@ suika.love",
             externalIds: [
               {
                 id: "thedarkthursday/suomi-lovely",
+                linkTypes: [
+                  "free streaming",
+                  "paid download",
+                ],
                 provider: "bandcamp",
                 type: "track",
               },
@@ -89,6 +93,10 @@ suika.love",
             externalIds: [
               {
                 id: "thedarkthursday/bittersweet-desires-to-overdose-on-my-prescriptions",
+                linkTypes: [
+                  "free streaming",
+                  "paid download",
+                ],
                 provider: "bandcamp",
                 type: "track",
               },
@@ -104,6 +112,10 @@ suika.love",
             externalIds: [
               {
                 id: "thedarkthursday/set-fire-to-the-space-snow",
+                linkTypes: [
+                  "free streaming",
+                  "paid download",
+                ],
                 provider: "bandcamp",
                 type: "track",
               },

--- a/providers/Bandcamp/json_types.ts
+++ b/providers/Bandcamp/json_types.ts
@@ -189,7 +189,8 @@ export interface TrackInfo {
 	/** Indicates whether the track can be streamed (can also be `1` for unreleased tracks). */
 	streaming: 1; // = boolean `1 | null`?
 	is_downloadable: boolean | null;
-	has_free_download: null;
+	/** Indicates whether the track is available for free download only (not for purchase). */
+	has_free_download: boolean | null;
 	free_album_download: boolean;
 	/** Duration in seconds (floating point, `0.0` for unreleased tracks). */
 	duration: number;

--- a/providers/Bandcamp/mod.ts
+++ b/providers/Bandcamp/mod.ts
@@ -378,21 +378,18 @@ export class BandcampReleaseLookup extends ReleaseLookup<BandcampProvider, Relea
 			title = title.replace(`${artist} - `, '');
 		}
 
-		const externalIds = title_link ? this.provider.makeExternalIdsFromUrl(title_link, this.rawReleaseUrl) : [];
-		if (externalIds.length > 0) {
-			const linkTypes = this.provider.getTrackLinkTypes(rawTrack);
-			if (linkTypes.length > 0) {
-				externalIds[0].linkTypes = linkTypes;
-			}
-		}
-
 		return {
 			number: trackNumber,
 			title,
 			artists: artist ? [this.makeArtistCreditName(artist)] : undefined,
 			length: rawTrack.duration * 1000,
 			recording: {
-				externalIds,
+				externalIds: title_link
+					? this.provider.makeExternalIdsFromUrl(title_link, {
+						baseUrl: this.rawReleaseUrl,
+						linkTypes: this.provider.getTrackLinkTypes(rawTrack),
+					})
+					: [],
 			},
 		};
 	}

--- a/providers/base.ts
+++ b/providers/base.ts
@@ -170,9 +170,20 @@ export abstract class MetadataProvider {
 	}
 
 	/** Creates external entity IDs from the given provider entity URL. */
-	makeExternalIdsFromUrl(entityUrl: URL | string, baseUrl?: URL | string): ExternalEntityId[] {
-		const entityId = this.extractEntityFromUrl(new URL(entityUrl, baseUrl));
-		return entityId ? this.makeExternalIds(entityId) : [];
+	makeExternalIdsFromUrl(entityUrl: URL | string, options: {
+		baseUrl?: URL | string;
+		linkTypes?: LinkType[];
+	} = {}): ExternalEntityId[] {
+		const entityId = this.extractEntityFromUrl(new URL(entityUrl, options.baseUrl));
+		if (entityId) {
+			const externalIds = this.makeExternalIds(entityId);
+			if (options.linkTypes?.length) {
+				externalIds[0].linkTypes = options.linkTypes;
+			}
+			return externalIds;
+		} else {
+			return [];
+		}
 	}
 
 	/** Returns the quality rating of the given feature. */

--- a/server/components/LinkWithMusicBrainz.tsx
+++ b/server/components/LinkWithMusicBrainz.tsx
@@ -38,7 +38,7 @@ export function LinkWithMusicBrainz({ entity, entityType, sourceEntityUrl, entit
 		const provider = providers.findByName(externalId.provider)!;
 		return {
 			url: provider.constructUrl(externalId).href,
-			types: provider.getLinkTypesForEntity(externalId),
+			types: externalId.linkTypes ?? provider.getLinkTypesForEntity(externalId),
 		};
 	}).filter((link) => !existingLinks.has(link.url));
 


### PR DESCRIPTION
- stream for free, download for free and purchase for download are populated correctly;
- pay what you want is not populated, because that requires some redesign (to query the individual tracks from bandcamp and check their pricing options); more info here #95.