### PR TITLE
Detect soundtrack based on the release title

### DIFF
--- a/harmonizer/release_types.test.ts
+++ b/harmonizer/release_types.test.ts
@@ -64,9 +64,6 @@ describe('release types', () => {
 				'EUPHORIA SEASON 2 OFFICIAL SCORE (FROM THE HBO ORIGINAL SERIES)',
 				'The Bible (Official Score Soundtrack)',
 				'The Good Wife (The Official TV Score)',
-				// Releases with OST abbreviation
-				'O.S.T. Das Boot',
-				'Alvin & The Chipmunks / OST',
 				// German release titles
 				'Get Up (Der Original Soundtrack zum Kinofilm)',
 				'Ein Mädchen namens Willow - Soundtrack zum Film',
@@ -83,14 +80,29 @@ describe('release types', () => {
 			].map((
 				title,
 			): FunctionSpec<typeof guessTypesFromTitle>[number] => [
-				'should detect soundtrack type',
+				`should detect soundtrack type (${title})`,
+				title,
+				new Set(['Soundtrack']),
+			])),
+		];
+
+		const passingCaseSensitiveCases: FunctionSpec<typeof guessTypesFromTitle> = [
+			// Soundtrack releases
+			...([
+				// Releases with OST abbreviation
+				'O.S.T. Das Boot',
+				'Alvin & The Chipmunks / OST',
+			].map((
+				title,
+			): FunctionSpec<typeof guessTypesFromTitle>[number] => [
+				`should detect soundtrack type (${title})`,
 				title,
 				new Set(['Soundtrack']),
 			])),
 		];
 
 		describe('exact case match', () => {
-			passingCases.forEach(([description, input, expected]) => {
+			[...passingCases, ...passingCaseSensitiveCases].forEach(([description, input, expected]) => {
 				it(description, () => {
 					assertEquals(guessTypesFromTitle(input), expected);
 				});

--- a/harmonizer/release_types.test.ts
+++ b/harmonizer/release_types.test.ts
@@ -42,6 +42,51 @@ describe('release types', () => {
 			['should detect type before comment', 'Enter Suicidal Angels - EP (Remastered 2021)', new Set(['EP'])],
 			['should detect EP suffix', 'Zero Distance EP', new Set(['EP'])],
 			['should detect demo type', 'Parasite Inc. (Demo)', new Set(['Demo'])],
+			// Soundtrack releases
+			...([
+				// Titles with original/official <medium> soundtrack
+				'The Lord of the Rings: The Return of the King (Original Motion Picture Soundtrack)',
+				'The Bodyguard - Original Soundtrack Album',
+				'Plants Vs. Zombies (Original Video Game Soundtrack)',
+				'Stardew Valley (Original Game Soundtrack)',
+				'L.A. Noire Official Soundtrack',
+				'Tarzan (Deutscher Original Film-Soundtrack)',
+				'Die Eiskönigin Völlig Unverfroren (Deutscher Original Film Soundtrack)',
+				// Soundtrack from the ... <medium>
+				'KPop Demon Hunters (Soundtrack from the Netflix Film)',
+				'The Witcher: Season 2 (Soundtrack from the Netflix Original Series)',
+				'The White Lotus (Soundtrack from the HBO® Original Limited Series)',
+				'Inception (Music from the Motion Picture)',
+				// Releases referring to score instead of soundtrack
+				'Fantastic Mr. Fox - Additional Music From The Original Score By Alexandre Desplat - The Abbey Road Mixes',
+				'Scott Pilgrim Vs. The World (Original Score Composed by Nigel Godrich)',
+				'F1® The Movie (Original Score By Hans Zimmer)',
+				'EUPHORIA SEASON 2 OFFICIAL SCORE (FROM THE HBO ORIGINAL SERIES)',
+				'The Bible (Official Score Soundtrack)',
+				'The Good Wife (The Official TV Score)',
+				// Releases with OST abbreviation
+				'O.S.T. Das Boot',
+				'Alvin & The Chipmunks / OST',
+				// German release titles
+				'Get Up (Der Original Soundtrack zum Kinofilm)',
+				'Ein Mädchen namens Willow - Soundtrack zum Film',
+				'Das Boot (Soundtrack zur TV Serie, zweite Staffel)',
+				// Swedish release titles
+				'Fucking Åmål - Musiken från filmen',
+				'Fejkpatient (Musik från TV-serien)',
+				'Kärlek Fårever (Soundtrack till Netflix-filmen)',
+				// Norwegian release titles
+				'Kvitebjørn (Musikken fra filmen)',
+				'Døden på Oslo S (Musikken fra teaterforestillingen)',
+				// Musical releases
+				'The Lion King: Original Broadway Cast Recording',
+			].map((
+				title,
+			): FunctionSpec<typeof guessTypesFromTitle>[number] => [
+				'should detect soundtrack type',
+				title,
+				new Set(['Soundtrack']),
+			])),
 		];
 
 		describe('exact case match', () => {

--- a/harmonizer/release_types.ts
+++ b/harmonizer/release_types.ts
@@ -22,7 +22,7 @@ const releaseGroupTypeMatchers: Array<{ type?: ReleaseGroupType; pattern: RegExp
 	{
 		type: 'Soundtrack',
 		pattern:
-			/(?:Original\s|Official\s)(?:(?:(?:Video\s)?Game|Motion Picture|Film|Movie|Television|TV|(?:(?:TV|Television)[\s-]?)?(?:Mini[\s-]?)?Series?|Musical)[\s-])?(?:Soundtrack|Score)/i,
+			/(?:Original|Official)\s(?:(?:(?:Video\s)?Game|Motion Picture|Film|Movie|Television|TV|(?:(?:TV|Television)[\s-]?)?(?:Mini[\s-]?)?Series?|Musical)[\s-])?(?:Soundtrack|Score)/i,
 	},
 	// Common soundtrack title: "Soundtrack from the <Medium>", should also match "Soundtrack from the <Streaming service> <Medium>"
 	{
@@ -61,10 +61,9 @@ export function guessTypesFromTitle(title: string): Set<ReleaseGroupType> {
 			return;
 		}
 		const type = match[1] || matcher.type;
-		if (!type) {
-			return;
+		if (type) {
+			types.add(capitalizeReleaseType(type));
 		}
-		types.add(capitalizeReleaseType(type));
 	});
 	return types;
 }

--- a/harmonizer/release_types.ts
+++ b/harmonizer/release_types.ts
@@ -56,6 +56,11 @@ const releaseGroupTypeMatchers: Array<{ type?: ReleaseGroupType; pattern: RegExp
 export function guessTypesFromTitle(title: string): Set<ReleaseGroupType> {
 	const types = new Set<ReleaseGroupType>();
 	releaseGroupTypeMatchers.forEach((matcher) => {
+		if (matcher.type && types.has(matcher.type)) {
+			// Release has already been assigned this type.
+			return;
+		}
+
 		const match = title.match(matcher.pattern);
 		if (!match) {
 			return;

--- a/harmonizer/release_types.ts
+++ b/harmonizer/release_types.ts
@@ -21,8 +21,7 @@ const releaseGroupTypeMatchers: Array<{ type?: ReleaseGroupType; pattern: RegExp
 	// Common soundtrack title: "Official/Original <Medium> Soundtrack" and "Original Score"
 	{
 		type: 'Soundtrack',
-		pattern:
-			/(?:Original|Official)\s(?:(?:(?:Video\s)?Game|Motion Picture|Film|Movie|Television|TV|(?:(?:TV|Television)[\s-]?)?(?:Mini[\s-]?)?Series?|Musical)[\s-])?(?:Soundtrack|Score)/i,
+		pattern: /(?:Original|Official)(?:.*?)(?:Soundtrack|Score)/i,
 	},
 	// Common soundtrack title: "Soundtrack from the <Medium>", should also match "Soundtrack from the <Streaming service> <Medium>"
 	{


### PR DESCRIPTION
Closes: https://github.com/kellnerd/harmony/issues/105

Implements auto-detection of soundtrack releases based the title based on a wide range of common title patterns. Supports both common title formats in English (which often are used for releases in other languages as well), German, Swedish, and Norwegian.

I've added test cases for a wide variation of soundtracks.

In contrast to the existing patterns for detecting release group types from the title, the pattern does not always capture the type and as such I had to come up with a way of associating the pattern to a type. I think this can probably be useful for when detecting more release group types from titles in the future.