### PR TITLE
Add `.env.example` file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Source code URL.
+HARMONY_CODE_URL=
+# User support URL.
+HARMONY_SUPPORT_URL=
+# Base URL of the MusicBrainz API which should be used to request data.
+HARMONY_MB_API_URL=
+# Base URL of the MusicBrainz server which should be targeted (by links and for seeding).
+HARMONY_MB_TARGET_URL=
+# Current git revision of the app.
+DENO_DEPLOYMENT_ID=
+# Path to the directory where the app should persist data like snapshots.
+HARMONY_DATA_DIR=
+# Indicates whether the protocol of a client from the `X-Forwarded-Proto` proxy header should be used.
+FORWARD_PROTO=
+# Port to serve the app on.
+PORT=
+
+# Provider API config
+
+# Spotify app config. See https://developer.spotify.com/documentation/web-api
+HARMONY_SPOTIFY_CLIENT_ID=
+HARMONY_SPOTIFY_CLIENT_SECRET=
+# Tidal app config. See https://developer.tidal.com/reference/web-api
+HARMONY_TIDAL_CLIENT_ID=
+HARMONY_TIDAL_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Alternatively you can run the [predefined task](deno.json) which automatically s
 deno task server
 ```
 
-Other environment variables which are used by the server are documented in the [configuration module](config.ts).
+Other environment variables which are used by the server are documented in the [configuration module](config.ts) and in the [`.env.example` file](.env.example). To get started, copy `.env.example` to `.env`. Most environment variables are optional and have default values in the code. To use some providers, you need to create an app with that provider. After which, you'll get a set of client credentials, which you need to assign to the corresponding environment variables.
 
 There is also a small command line app which can be used for testing:
 

--- a/deno.json
+++ b/deno.json
@@ -15,6 +15,7 @@
 		"@deno/gfm": "jsr:@deno/gfm@^0.8.0",
 		"@kellnerd/musicbrainz": "jsr:@kellnerd/musicbrainz@^0.4.1",
 		"@std/collections": "jsr:@std/collections@^1.0.10",
+		"@std/dotenv": "jsr:@std/dotenv@^0.225.5",
 		"@std/path": "jsr:@std/path@^1.0.8",
 		"@std/testing": "jsr:@std/testing@^1.0.9",
 		"@std/uuid": "jsr:@std/uuid@^1.0.6",

--- a/providers/Spotify/mod.test.ts
+++ b/providers/Spotify/mod.test.ts
@@ -1,5 +1,5 @@
 // Automatically load .env environment variable file (before anything else).
-import 'std/dotenv/load.ts';
+import '@std/dotenv/load';
 
 import type { ReleaseOptions } from '@/harmonizer/types.ts';
 import { describeProvider, makeProviderOptions } from '@/providers/test_spec.ts';

--- a/providers/Tidal/mod.test.ts
+++ b/providers/Tidal/mod.test.ts
@@ -1,5 +1,5 @@
 // Automatically load .env environment variable file (before anything else).
-import 'std/dotenv/load.ts';
+import '@std/dotenv/load';
 
 import type { HarmonyRelease } from '@/harmonizer/types.ts';
 import { describeProvider, makeProviderOptions } from '@/providers/test_spec.ts';

--- a/server/dev.ts
+++ b/server/dev.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run -A --watch=static/,routes/
 
 // Automatically load .env environment variable file (before anything else).
-import 'std/dotenv/load.ts';
+import '@std/dotenv/load';
 
 import dev from 'fresh/dev.ts';
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,5 +1,5 @@
 // Automatically load .env environment variable file and configure logger (before anything else).
-import 'std/dotenv/load.ts';
+import '@std/dotenv/load';
 import './logging.ts';
 
 import { shortRevision } from '@/config.ts';


### PR DESCRIPTION
Closes: https://github.com/kellnerd/harmony/issues/48

Adds an `.env.example` file with the environment variables used in the code. Also updates the readme with some info about the file. 

The  `std/dotenv` was changed to use `@std/dotenv` instead since prior to [`@std/dotenv` at version `0.225.0`](https://github.com/denoland/std/releases/tag/release-2024.07.19) the `.env.example` file was used to require which environments had to be present, so it would throw an error if you hadn't set an environment variable that was listed in the `.env.example` file.