### PR TITLE
Detect remix based on the release title

### DIFF
--- a/harmonizer/release_types.test.ts
+++ b/harmonizer/release_types.test.ts
@@ -84,6 +84,56 @@ describe('release types', () => {
 				title,
 				new Set(['Soundtrack']),
 			])),
+			// Remix releases
+			...([
+				'Human (Paul Woolford Remix)',
+				'Paper Romance (Purple Disco Machine Remix - Edit)',
+				'Paper Romance (Purple Disco Machine Remix) [Edit]',
+				'Paper Romance (Purple Disco Machine Remix) (Edit)',
+				'Paper Romance (Purple Disco Machine Remix; Edit)',
+				"Stay (Don't Go Away) [feat. Raye] [Nicky Romero Remix]",
+				'Anti‐Hero (Kungs remix extended version)',
+				'Remix',
+				'Anti‐Hero (Remixes)',
+				'The One (feat. Daddy Yankee) [The Remixes]',
+				'The Remixes',
+				'The Remixes - Vol.1',
+				'The Remixes, Pt. 1',
+				'Remixes',
+				'Remixes 81>04',
+				'Never Say Never - The Remixes',
+				'Skin: The Remixes',
+				'The Hills Remixes',
+				'MIDI Kittyy - The Remixes Vol 1',
+				'The Slow Rush B-Sides & Remixes',
+				'Remixed',
+				'Remixed (2003 Remaster)',
+				'Remixed Sides',
+				'Remixed: The Definitive Collection',
+				'The Hits: Remixed',
+				'Remixed & Revisited',
+				'Revived Remixed Revisited',
+				'Welcome To My World (Remixed)',
+				'Mörkrets Narr Remixed',
+			].map((
+				title,
+			): FunctionSpec<typeof guessTypesFromTitle>[number] => [
+				`should detect remix type (${title})`,
+				title,
+				new Set(['Remix']),
+			])),
+			['should not treat a premix as remix', 'Wild (premix version)', new Set()],
+			// Multiple types
+			[
+				'should detect both remix and soundtrack type',
+				'The Sims 2: Nightlife (Remixes) (Original Soundtrack)',
+				new Set(['Remix', 'Soundtrack']),
+			],
+			[
+				'should detect both remix and soundtrack type',
+				'Remixes - EP',
+				new Set(['EP', 'Remix']),
+			],
 		];
 
 		const passingCaseSensitiveCases: FunctionSpec<typeof guessTypesFromTitle> = [

--- a/harmonizer/release_types.ts
+++ b/harmonizer/release_types.ts
@@ -18,6 +18,8 @@ const releaseGroupTypeMatchers: Array<{ type?: ReleaseGroupType; pattern: RegExp
 	{ pattern: /\s- (EP|Single|Live)(?:\s\(.*?\))?$/i },
 	// Generic "EP" suffix
 	{ pattern: /\s(EP)(?:\s\(.*?\))?$/i },
+	// Common remix title: "Remixed", "The Remixes", or "<Track name> (<Remixer> remix)".
+	{ pattern: /\b(Remix)(?:e[sd])?\b/i },
 	// Common soundtrack title: "Official/Original <Medium> Soundtrack" and "Original Score"
 	{
 		type: 'Soundtrack',


### PR DESCRIPTION
Part of: https://github.com/kellnerd/harmony/issues/15

Detects if a release is a remix based on the title. Basically, does it contain "remix", "remixes", or "remixed". Initially, I tried to use some very clever regexes. But I realized, in most cases it is probably just enough to check if the title contains one of the words.