### PR TITLE
feat: Detect DJ-mix based on the release title or track titles

### DIFF
--- a/harmonizer/release_types.test.ts
+++ b/harmonizer/release_types.test.ts
@@ -1,5 +1,6 @@
 import {
 	capitalizeReleaseType,
+	guessDjMixRelease,
 	guessLiveRelease,
 	guessTypesForRelease,
 	guessTypesFromTitle,
@@ -15,7 +16,7 @@ import type { FunctionSpec } from '../utils/test_spec.ts';
 
 describe('release types', () => {
 	describe('guess types for release', () => {
-		const passingCases: Array<[string, HarmonyRelease, string[]]> = [
+		const passingCases: Array<[string, HarmonyRelease, ReleaseGroupType[]]> = [
 			['should detect EP type from title', makeRelease('Wake of a Nation (EP)'), ['EP']],
 			['should keep existing types', makeRelease('Wake of a Nation (EP)', ['Interview']), ['EP', 'Interview']],
 			['should detect live type from title', makeRelease('One Second (Live)'), ['Live']],
@@ -23,6 +24,15 @@ describe('release types', () => {
 				'should detect live type from tracks',
 				makeRelease('One Second', undefined, [{ title: 'One Second - Live' }, { title: 'Darker Thoughts - Live' }]),
 				['Live'],
+			],
+			['should detect DJ-mix type from title', makeRelease('DJ-Kicks (Forest Swords) [DJ Mix]'), ['DJ-mix']],
+			[
+				'should detect DJ-mix type from tracks',
+				makeRelease('DJ-Kicks: Modeselektor', undefined, [
+					{ title: 'PREY - Mixed' },
+					{ title: 'Permit Riddim - Mixed' },
+				]),
+				['DJ-mix'],
 			],
 		];
 
@@ -123,6 +133,21 @@ describe('release types', () => {
 				new Set(['Remix']),
 			])),
 			['should not treat a premix as remix', 'Wild (premix version)', new Set()],
+			// DJ Mix releases
+			...([
+				'Kitsuné Musique Mixed by YOU LOVE HER (DJ Mix)',
+				'Club Life - Volume One Las Vegas (Continuous DJ Mix)',
+				'DJ-Kicks (Forest Swords) [DJ Mix]',
+				'Paragon Continuous DJ Mix',
+				'Babylicious (Continuous DJ Mix by Baby Anne)',
+			].map((
+				title,
+			): FunctionSpec<typeof guessTypesFromTitle>[number] => [
+				`should detect DJ-mix type (${title})`,
+				title,
+				new Set(['DJ-mix']),
+			])),
+			['should not treat just DJ mix as DJ-mix', 'DJ mix', new Set()],
 			// Multiple types
 			[
 				'should detect both remix and soundtrack type',
@@ -190,6 +215,81 @@ describe('release types', () => {
 		passingCases.forEach(([description, input, expected]) => {
 			it(description, () => {
 				assertEquals(guessLiveRelease(input), expected);
+			});
+		});
+	});
+
+	describe('guess DJ-mix release', () => {
+		const passingCases: FunctionSpec<typeof guessDjMixRelease> = [
+			['should be true if all tracks have mixed type', [
+				{
+					tracklist: [
+						{ title: 'Heavenly Hell (feat. Ne-Yo) (Mixed)' },
+						{ title: 'Clap Back (feat. Raphaella) (Mixed)' },
+						{ title: '2x2 (Mixed)' },
+					],
+				},
+			], true],
+			['should be true if all tracks on one medium have mixed type', [
+				{
+					tracklist: [
+						{ title: 'PREY - Mixed' },
+						{ title: 'Permit Riddim - Mixed' },
+						{ title: 'MEGA MEGA MEGA (DJ-Kicks) - Mixed' },
+					],
+				},
+				{
+					tracklist: [
+						{ title: 'PREY' },
+						{ title: 'Permit Riddim' },
+						{ title: 'MEGA MEGA MEGA (DJ-Kicks)' },
+					],
+				},
+			], true],
+			['should support " - Mixed" style', [
+				{
+					tracklist: [
+						{ title: 'Salute - Mixed' },
+						{ title: 'Friday - Mixed' },
+					],
+				},
+			], true],
+			['should support case insensitive of mixed', [
+				{
+					tracklist: [
+						{ title: 'Heavenly Hell (feat. Ne-Yo) (mixed)' },
+						{ title: 'Clap Back (feat. Raphaella) (mixed)' },
+						{ title: '2x2 (mixed)' },
+					],
+				},
+			], true],
+			['should support mixed usage of formats', [
+				{
+					tracklist: [
+						{ title: 'Heavenly Hell (feat. Ne-Yo) [Mixed]' },
+						{ title: 'Clap Back (feat. Raphaella) (Mixed)' },
+						{ title: '2x2 - Mixed' },
+					],
+				},
+			], true],
+			['should be false if not all tracks are mixed', [
+				{
+					tracklist: [
+						{ title: 'Heavenly Hell (feat. Ne-Yo) (Mixed)' },
+						{ title: 'Clap Back (feat. Raphaella)' },
+						{ title: '2x2 (Mixed)' },
+					],
+				},
+			], false],
+			['should be false for empty tracklist', [{
+				tracklist: [],
+			}], false],
+			['should be false for no medium', [], false],
+		];
+
+		passingCases.forEach(([description, input, expected]) => {
+			it(description, () => {
+				assertEquals(guessDjMixRelease(input), expected);
 			});
 		});
 	});


### PR DESCRIPTION
Part of: https://github.com/kellnerd/harmony/issues/15

Adds support for detecting DJ-mixes by their titles and/or if the track titles end with `(mixed)` (in different formats).

Contrary to detection of Live releases, there are examples of DJ-mixes having multiple media one with the mixed tracks and one with the unmixed tracks. Some examples of this are the DJ-Kicks releases: [DJ-Kicks: Modeselektor](https://open.spotify.com/album/4ApWMQXAEOaNpFWaKG2FtN) or [DJ-Kicks: Disclosure](https://open.spotify.com/album/7F0dkkAqwrmclRH8KP2QmW?si=-1SGBg4oQj6-8ZeSG4oVAg).

When searching on Spotify, there were a few releases just called `DJ mix` which do not seem to be DJ-mixes per se. Also, considered `Continuous Mix`, but that seemed to also include just tracks with seamless transitions but not DJ-mixes really.

## Some cases

- https://open.spotify.com/album/4VtQwmTZHlFxO6hw9hgu5J
- https://open.spotify.com/album/4ApWMQXAEOaNpFWaKG2FtN (first medium is DJ-mixed, second is the unmixed tracks. The release group should still be DJ-mix)
- https://open.spotify.com/album/0f1k2l7T0SDIuAGFoXVPnF (track names contain `mixed` and the release title ends with `(DJ mix)`)
- https://open.spotify.com/album/1Ufqq0yg7gEyRQ70ofgKXe (release title ends with `(Continuous DJ mix)`
- https://open.spotify.com/album/3YCh0CPUNvjvnuaJ459MZv (release title ends with `[DJ mix]`)
- https://music.apple.com/us/album/paragon-continuous-dj-mix-dj-mix/1755446194 (mixes `[Mixed]` and `(Mixed)` suffixes)
- https://open.spotify.com/album/5TaKyO5IvwE8nknuFmXpA4 (release title that just contains `Continuous DJ mix`)

## False negative:

- https://open.spotify.com/album/3uA7wc39YN6UmondQbxDrh (Last track title ends with `- Bonus track mixed`).