### PR TITLE
feat: Open all add external IDs links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ snaps/
 
 # Temporary files
 local/
+
+# Coverage directory
+coverage/

--- a/musicbrainz/edit_link.test.ts
+++ b/musicbrainz/edit_link.test.ts
@@ -1,0 +1,178 @@
+import { type EntityWithUrlRels, getEditUrlToSeedExternalLinks } from './edit_link.ts';
+import type { EntityId, LinkType, ResolvableEntity } from '@/harmonizer/types.ts';
+import type { EntityType } from '@kellnerd/musicbrainz/data/entity';
+import { describe, it } from '@std/testing/bdd';
+import { assertInstanceOf } from 'std/assert/assert_instance_of.ts';
+import { assertEquals } from 'std/assert/assert_equals.ts';
+import type { MetadataProvider } from '@/providers/base.ts';
+import type { ProviderRegistry } from '@/providers/registry.ts';
+
+describe('getEditUrlToSeedExternalLinks', () => {
+	const entityType: EntityType = 'artist';
+	const sourceEntityUrl = new URL('https://source.com/entity/1');
+
+	const mockProviders = {
+		findByName: (_name: string) => ({
+			constructUrl: (entity: EntityId) => new URL(`https://example.com/${entity.id}`),
+			getLinkTypesForEntity: (_entity: EntityId): LinkType[] => ['paid download', 'free streaming'],
+		} as unknown as MetadataProvider),
+	} as unknown as ProviderRegistry;
+
+	it('returns null if entity has no externalIds', () => {
+		const entity: ResolvableEntity = { mbid: 'mbid-1', externalIds: [] };
+		assertEquals(
+			getEditUrlToSeedExternalLinks({ entity, entityType, sourceEntityUrl, providers: mockProviders }),
+			null,
+		);
+	});
+
+	it('returns null if entity has no mbid', () => {
+		const entity: ResolvableEntity = { externalIds: [{ type: '', provider: 'test', id: '1' }] };
+		assertEquals(
+			getEditUrlToSeedExternalLinks({ entity, entityType, sourceEntityUrl, providers: mockProviders }),
+			null,
+		);
+	});
+
+	it('returns null if all external links already exist', () => {
+		const entity: ResolvableEntity = {
+			mbid: 'mbid-2',
+			externalIds: [{ type: '', provider: 'test', id: '1' }],
+		};
+		const entityCache: EntityWithUrlRels[] = [{
+			id: 'mbid-2',
+			relations: [{ url: { resource: 'https://example.com/1' } }],
+		}];
+		assertEquals(
+			getEditUrlToSeedExternalLinks({
+				entity,
+				entityType,
+				sourceEntityUrl,
+				entityCache,
+				providers: mockProviders,
+			}),
+			null,
+		);
+	});
+
+	it('returns a URL with correct search params for new links', () => {
+		const entity: ResolvableEntity = {
+			mbid: 'mbid-3',
+			externalIds: [{ type: '', provider: 'test', id: '2', linkTypes: ['free download'] }],
+		};
+		const entityCache: EntityWithUrlRels[] = [{
+			id: 'mbid-3',
+			relations: [],
+		}];
+		const url = getEditUrlToSeedExternalLinks({
+			entity,
+			entityType,
+			sourceEntityUrl,
+			entityCache,
+			providers: mockProviders,
+		});
+		assertInstanceOf(url, URL);
+		assertEquals(
+			url!.origin,
+			'https://musicbrainz.org',
+		);
+		assertEquals(
+			url!.pathname,
+			'/artist/mbid-3/edit',
+		);
+		const searchParams = url!.searchParams;
+		assertEquals(searchParams.get('edit-artist.url.0.text'), 'https://example.com/2');
+		assertEquals(searchParams.get('edit-artist.url.0.link_type_id'), '177');
+		assertEquals(searchParams.get('edit-artist.url.1.text'), null);
+		assertEquals(searchParams.get('edit-artist.url.1.link_type_id'), null);
+		assertEquals(
+			searchParams.get('edit-artist.edit_note'),
+			'Matched artist while importing https://source.com/entity/1 with Harmony',
+		);
+	});
+
+	it('handles missing entityCache gracefully', () => {
+		const entity: ResolvableEntity = {
+			mbid: 'mbid-4',
+			externalIds: [{ type: '', provider: 'test', id: '3', linkTypes: ['free download'] }],
+		};
+		const url = getEditUrlToSeedExternalLinks({ entity, entityType, sourceEntityUrl, providers: mockProviders });
+		assertInstanceOf(url, URL);
+		const searchParams = url!.searchParams;
+		assertEquals(searchParams.get('edit-artist.url.0.text'), 'https://example.com/3');
+		assertEquals(searchParams.get('edit-artist.url.0.link_type_id'), '177'); // free download
+		assertEquals(searchParams.get('edit-artist.url.1.text'), null);
+		assertEquals(searchParams.get('edit-artist.url.1.link_type_id'), null);
+	});
+
+	it('defaults to provider link types if none are specified', () => {
+		const entity: ResolvableEntity = {
+			mbid: 'mbid-6',
+			externalIds: [{ type: '', provider: 'test', id: '5' }],
+		};
+		const entityCache: EntityWithUrlRels[] = [{
+			id: 'mbid-6',
+			relations: [],
+		}];
+		const url = getEditUrlToSeedExternalLinks({
+			entity,
+			entityType,
+			sourceEntityUrl,
+			entityCache,
+			providers: mockProviders,
+		});
+		assertInstanceOf(url, URL);
+		const searchParams = url!.searchParams;
+		assertEquals(searchParams.get('edit-artist.url.0.text'), 'https://example.com/5');
+		assertEquals(searchParams.get('edit-artist.url.0.link_type_id'), '176'); // paid download
+		assertEquals(searchParams.get('edit-artist.url.1.text'), 'https://example.com/5');
+		assertEquals(searchParams.get('edit-artist.url.1.link_type_id'), '194'); // free streaming
+		assertEquals(searchParams.get('edit-artist.url.2.text'), null);
+		assertEquals(searchParams.get('edit-artist.url.2.link_type_id'), null);
+	});
+
+	it('includes external links with empty link types', () => {
+		const entity: ResolvableEntity = {
+			mbid: 'mbid-7',
+			externalIds: [{ type: '', provider: 'test', id: '6', linkTypes: [] }],
+		};
+		const entityCache: EntityWithUrlRels[] = [{
+			id: 'mbid-7',
+			relations: [],
+		}];
+		const url = getEditUrlToSeedExternalLinks({
+			entity,
+			entityType,
+			sourceEntityUrl,
+			entityCache,
+			providers: mockProviders,
+		});
+		assertInstanceOf(url, URL);
+		const searchParams = url!.searchParams;
+		assertEquals(searchParams.get('edit-artist.url.0.text'), 'https://example.com/6');
+		assertEquals(searchParams.get('edit-artist.url.0.link_type_id'), null); // No link type
+		assertEquals(searchParams.get('edit-artist.url.1.text'), null);
+		assertEquals(searchParams.get('edit-artist.url.1.link_type_id'), null);
+	});
+
+	it('returns null if no new external links after filtering', () => {
+		const entity: ResolvableEntity = {
+			mbid: 'mbid-5',
+			externalIds: [{ type: '', provider: 'test', id: '4' }],
+		};
+		const entityCache: EntityWithUrlRels[] = [{
+			id: 'mbid-5',
+			relations: [{ url: { resource: 'https://example.com/4' } }],
+		}];
+		assertEquals(
+			getEditUrlToSeedExternalLinks({
+				entity,
+				entityType,
+				sourceEntityUrl,
+				entityCache,
+				providers: mockProviders,
+			}),
+			null,
+		);
+	});
+});

--- a/musicbrainz/edit_link.ts
+++ b/musicbrainz/edit_link.ts
@@ -1,0 +1,68 @@
+import { join } from 'std/url/join.ts';
+import { flatten } from 'utils/object/flatten.js';
+import { musicbrainzTargetServer } from '@/config.ts';
+import { convertLinkType } from '@/musicbrainz/seeding.ts';
+import type { EntityType } from '@kellnerd/musicbrainz/data/entity';
+import type { EntityWithMbid } from '@kellnerd/musicbrainz/api-types';
+import type { ExternalLink, ResolvableEntity } from '@/harmonizer/types.ts';
+import type { ProviderRegistry } from '@/providers/registry.ts';
+
+// TODO: incomplete type, expose a suitable type from @kellnerd/musicbrainz?
+// interface $EntityWithUrlRels extends EntityWithMbid, WithRels<'url-rels'> {}
+// type EntityWithUrlRels = WithIncludes<$EntityWithUrlRels, 'url-rels'>
+export interface EntityWithUrlRels extends EntityWithMbid {
+	relations: Array<{
+		url: {
+			resource: string;
+		};
+	}>;
+}
+
+export function getEditUrlToSeedExternalLinks(
+	{ entity, entityType, sourceEntityUrl, entityCache, providers }: {
+		entity: ResolvableEntity;
+		entityType: EntityType;
+		sourceEntityUrl: URL;
+		entityCache?: EntityWithUrlRels[];
+		/**
+		 * Registry of available metadata providers to construct external URLs and get link types.
+		 * Sent as a parameter to allow easier testing/mocking.
+		 */
+		providers: ProviderRegistry;
+	},
+): URL | null {
+	if (!entity.externalIds?.length || !entity.mbid) return null;
+
+	// Get the entity from the cache and check which links already exist in MB.
+	const mbEntity = entityCache?.find((e) => e.id === entity.mbid);
+	const existingLinks = new Set(mbEntity?.relations.map((urlRel) => urlRel.url.resource));
+
+	// Convert external IDs into links and discard those which already exist.
+	const externalLinks: ExternalLink[] = entity.externalIds.map((externalId) => {
+		const provider = providers.findByName(externalId.provider)!;
+		return {
+			url: provider.constructUrl(externalId).href,
+			types: externalId.linkTypes ?? provider.getLinkTypesForEntity(externalId),
+		};
+	}).filter((link) => !existingLinks.has(link.url));
+
+	if (!externalLinks.length) return null;
+
+	// Construct link to seed the MB entity editor.
+	const mbEditLink = join(musicbrainzTargetServer, entityType, entity.mbid, 'edit');
+	mbEditLink.search = new URLSearchParams(flatten({
+		[`edit-${entityType}`]: {
+			url: externalLinks.flatMap((link) =>
+				link.types?.length
+					? link.types.map((type) => ({
+						text: link.url,
+						link_type_id: convertLinkType(entityType, type, new URL(link.url)),
+					}))
+					: ({ text: link.url })
+			),
+			edit_note: `Matched ${entityType} while importing ${sourceEntityUrl} with Harmony`,
+		},
+	})).toString();
+
+	return mbEditLink;
+}

--- a/server/components/LinkWithMusicBrainz.tsx
+++ b/server/components/LinkWithMusicBrainz.tsx
@@ -1,67 +1,64 @@
 import { LinkedEntity } from './LinkedEntity.tsx';
 import { SpriteIcon } from './SpriteIcon.tsx';
+import { OpenAllLinks } from '@/server/islands/OpenAllLinks.tsx';
 
-import { musicbrainzTargetServer } from '@/config.ts';
-import type { ExternalLink, ResolvableEntity } from '@/harmonizer/types.ts';
-import { convertLinkType } from '@/musicbrainz/seeding.ts';
-import { providers } from '@/providers/mod.ts';
-import type { EntityWithMbid } from '@kellnerd/musicbrainz/api-types';
 import type { EntityType } from '@kellnerd/musicbrainz/data/entity';
-import { join } from 'std/url/join.ts';
-import { flatten } from 'utils/object/flatten.js';
+import { type EntityWithUrlRels, getEditUrlToSeedExternalLinks } from '@/musicbrainz/edit_link.ts';
+import type { ResolvableEntity } from '@/harmonizer/types.ts';
+import { isDefined } from '@/utils/predicate.ts';
+import { providers } from '@/providers/mod.ts';
 
-// TODO: incomplete type, expose a suitable type from @kellnerd/musicbrainz?
-// interface $EntityWithUrlRels extends EntityWithMbid, WithRels<'url-rels'> {}
-// type EntityWithUrlRels = WithIncludes<$EntityWithUrlRels, 'url-rels'>
-export interface EntityWithUrlRels extends EntityWithMbid {
-	relations: Array<{
-		url: {
-			resource: string;
-		};
-	}>;
-}
-
-export function LinkWithMusicBrainz({ entity, entityType, sourceEntityUrl, entityCache }: {
-	entity: ResolvableEntity;
+/**
+ * Renders a list of MusicBrainz edit links to add external links, based on the provided entities and entity type.
+ * If multiple entities are present, a button to open all MusicBrainz edit links at once is shown.
+ */
+export function LinkWithMusicBrainz({ entities, entityType, sourceEntityUrl, entityCache }: {
+	entities: ResolvableEntity[];
 	entityType: EntityType;
 	sourceEntityUrl: URL;
 	entityCache?: EntityWithUrlRels[];
 }) {
-	if (!entity.externalIds?.length || !entity.mbid) return null;
+	// No entities or no source entity URL to link from, nothing to render.
+	if (!sourceEntityUrl) return null;
 
-	// Get the entity from the cache and check which links already exist in MB.
-	const mbEntity = entityCache?.find((e) => e.id === entity.mbid);
-	const existingLinks = new Set(mbEntity?.relations.map((urlRel) => urlRel.url.resource));
+	const entitiesWithMbEditLinks = entities.map((entity) => {
+		const mbEditLink = getEditUrlToSeedExternalLinks({ entity, entityType, sourceEntityUrl, entityCache, providers });
+		if (mbEditLink) {
+			return { entity, mbEditLink };
+		}
+	}).filter(isDefined);
 
-	// Convert external IDs into links and discard those which already exist.
-	const externalLinks: ExternalLink[] = entity.externalIds.map((externalId) => {
-		const provider = providers.findByName(externalId.provider)!;
-		return {
-			url: provider.constructUrl(externalId).href,
-			types: externalId.linkTypes ?? provider.getLinkTypesForEntity(externalId),
-		};
-	}).filter((link) => !existingLinks.has(link.url));
+	if (entitiesWithMbEditLinks.length === 0) return null;
 
-	if (!externalLinks.length) return null;
+	const actions = entitiesWithMbEditLinks.map(({ entity, mbEditLink }) => (
+		<LinkWithMusicBrainzAction
+			mbEditLink={mbEditLink}
+			entity={entity}
+			entityType={entityType}
+		/>
+	));
+	if (actions.length > 1) {
+		return (
+			<div class='action-group'>
+				<OpenAllLinks
+					links={entitiesWithMbEditLinks.map(({ mbEditLink }) => mbEditLink.href)}
+					linkType={entityType}
+				/>
+				{actions}
+			</div>
+		);
+	} else {
+		return actions[0];
+	}
+}
 
-	// Construct link to seed the MB entity editor.
-	const mbEditLink = join(musicbrainzTargetServer, entityType, entity.mbid, 'edit');
-	mbEditLink.search = new URLSearchParams(flatten({
-		[`edit-${entityType}`]: {
-			url: externalLinks.flatMap((link) =>
-				link.types?.length
-					? link.types.map((type) => ({
-						text: link.url,
-						link_type_id: convertLinkType(entityType, type, new URL(link.url)),
-					}))
-					: ({ text: link.url })
-			),
-			edit_note: `Matched ${entityType} while importing ${sourceEntityUrl} with Harmony`,
-		},
-	})).toString();
-
+function LinkWithMusicBrainzAction({ mbEditLink, entity, entityType }: {
+	mbEditLink: URL;
+	entity: ResolvableEntity;
+	entityType: EntityType;
+}) {
 	return (
-		<div class='message'>
+		<div class='action'>
 			<SpriteIcon name='link' />
 			<div>
 				<p>

--- a/server/fresh.gen.ts
+++ b/server/fresh.gen.ts
@@ -11,6 +11,7 @@ import * as $release from './routes/release.tsx';
 import * as $release_actions from './routes/release/actions.tsx';
 import * as $settings from './routes/settings.tsx';
 import * as $CopyButton from './islands/CopyButton.tsx';
+import * as $OpenAllLinks from './islands/OpenAllLinks.tsx';
 import * as $PersistentInput from './islands/PersistentInput.tsx';
 import * as $RegionList from './islands/RegionList.tsx';
 import * as $ReleaseSeeder from './islands/ReleaseSeeder.tsx';
@@ -29,6 +30,7 @@ const manifest = {
 	},
 	islands: {
 		'./islands/CopyButton.tsx': $CopyButton,
+		'./islands/OpenAllLinks.tsx': $OpenAllLinks,
 		'./islands/PersistentInput.tsx': $PersistentInput,
 		'./islands/RegionList.tsx': $RegionList,
 		'./islands/ReleaseSeeder.tsx': $ReleaseSeeder,

--- a/server/islands/OpenAllLinks.tsx
+++ b/server/islands/OpenAllLinks.tsx
@@ -1,0 +1,89 @@
+import { SpriteIcon } from '@/server/components/SpriteIcon.tsx';
+import { Button } from '@/server/components/Button.tsx';
+import type { EntityType } from '@kellnerd/musicbrainz/data/entity';
+import { useSignal } from '@preact/signals';
+
+/**
+ * Delay between every pop-up, in milliseconds.
+ */
+const popUpDelay = 300;
+const blockedPopUpMessage = 'Pop-up was blocked';
+
+export function OpenAllLinks({ links, linkType }: {
+	links: string[];
+	linkType: EntityType;
+}) {
+	const showBlockedPopUpWarning = useSignal(false);
+	const numberOfLinks = links.length;
+	// Only show the button if there are multiple links to open.
+	if (numberOfLinks <= 1) return null;
+
+	async function openAllLinks() {
+		if (numberOfLinks >= 10 && !globalThis.confirm(`This will open ${numberOfLinks} new tabs. Continue?`)) return;
+
+		const controller = new AbortController();
+		const signal = controller.signal;
+
+		const newWindowPromises = links.map((link, index) =>
+			new Promise<void>((resolve, reject) => {
+				if (!link) return resolve();
+
+				const timeoutId = setTimeout(() => {
+					const newWindow = globalThis.open(link, '_blank');
+					const isBlocked = !newWindow || newWindow.closed || typeof newWindow.closed === 'undefined';
+
+					if (isBlocked) {
+						// If the pop-up was blocked, reject the promise with a specific message.
+						return reject(new Error(blockedPopUpMessage));
+					}
+
+					return resolve();
+				}, index * popUpDelay);
+
+				// If the controller is aborted, clear the timeout and reject the promise.
+				signal.addEventListener('abort', () => {
+					clearTimeout(timeoutId);
+					reject();
+				});
+			})
+		);
+
+		try {
+			await Promise.all(newWindowPromises);
+			// If all pop-ups were opened, hide warning if it was visible.
+			showBlockedPopUpWarning.value = false;
+		} catch (error) {
+			if (error instanceof Error && error.message === blockedPopUpMessage) {
+				// Abort all pending pop-ups.
+				controller.abort();
+				// Show warning if the browser blocked the pop-up.
+				showBlockedPopUpWarning.value = true;
+			}
+		}
+	}
+
+	return (
+		<>
+			<div class='action'>
+				<SpriteIcon name='external-link' />
+				<Button
+					class='open-all-links'
+					onClick={openAllLinks}
+					title={`This will open ${numberOfLinks} tabs (pop-up)`}
+				>
+					Open all {numberOfLinks} {linkType} links
+				</Button>
+			</div>
+			{showBlockedPopUpWarning.value && (
+				<div class='message warning'>
+					<SpriteIcon name='alert-triangle' />
+					<div>
+						<p>
+							Your browser may have blocked the pop-ups. Please allow pop-ups for this site and try again.
+						</p>
+					</div>
+				</div>
+			)}
+		</>
+	);
+}

--- a/server/routes/icon-sprite.svg.tsx
+++ b/server/routes/icon-sprite.svg.tsx
@@ -15,6 +15,7 @@ import IconCopyCheck from 'tabler-icons/copy-check.tsx';
 import IconDatabaseEdit from 'tabler-icons/database-edit.tsx';
 import IconDatabaseImport from 'tabler-icons/database-import.tsx';
 import IconDisc from 'tabler-icons/disc.tsx';
+import IconExternalLink from 'tabler-icons/external-link.tsx';
 import IconHelp from 'tabler-icons/help.tsx';
 import IconInfoCircle from 'tabler-icons/info-circle.tsx';
 import IconLink from 'tabler-icons/link.tsx';
@@ -40,6 +41,7 @@ const icons: Icon[] = [
 	IconDatabaseEdit,
 	IconDatabaseImport,
 	IconDisc,
+	IconExternalLink,
 	IconHelp,
 	IconInfoCircle,
 	IconLink,

--- a/server/routes/release/actions.tsx
+++ b/server/routes/release/actions.tsx
@@ -1,7 +1,7 @@
 import { ArtistCredit } from '@/server/components/ArtistCredit.tsx';
 import { CoverImage } from '@/server/components/CoverImage.tsx';
 import { MagicISRC } from '@/server/components/ISRCSubmission.tsx';
-import { type EntityWithUrlRels, LinkWithMusicBrainz } from '@/server/components/LinkWithMusicBrainz.tsx';
+import { LinkWithMusicBrainz } from '@/server/components/LinkWithMusicBrainz.tsx';
 import { MBIDInput } from '@/server/components/MBIDInput.tsx';
 import { MessageBox } from '@/server/components/MessageBox.tsx';
 import { ProviderList } from '@/server/components/ProviderList.tsx';
@@ -30,6 +30,7 @@ import { Head } from 'fresh/runtime.ts';
 import { defineRoute } from 'fresh/server.ts';
 import { getLogger } from 'std/log/get_logger.ts';
 import { join } from 'std/url/join.ts';
+import type { EntityWithUrlRels } from '@/musicbrainz/edit_link.ts';
 
 export default defineRoute(async (req, ctx) => {
 	const errors: Error[] = [];
@@ -175,7 +176,7 @@ export default defineRoute(async (req, ctx) => {
 					/>
 				))}
 				{releaseUrl && (
-					<div class='message'>
+					<div class='action'>
 						<SpriteIcon name='brand-metabrainz' />
 						<p>
 							<a href={releaseUrl.href}>
@@ -185,7 +186,7 @@ export default defineRoute(async (req, ctx) => {
 					</div>
 				)}
 				{release && isrcProvider && (
-					<div class='message'>
+					<div class='action'>
 						<SpriteIcon name='disc' />
 						<p>
 							<MagicISRC release={release} targetMbid={releaseMbid!} />
@@ -193,20 +194,24 @@ export default defineRoute(async (req, ctx) => {
 						</p>
 					</div>
 				)}
-				{releaseUrl &&
-					allArtists.map((artist) => (
-						<LinkWithMusicBrainz
-							entity={artist}
-							entityType='artist'
-							sourceEntityUrl={releaseUrl}
-							entityCache={mbArtists}
-						/>
-					))}
-				{release?.labels?.map((label) => (
-					<LinkWithMusicBrainz entity={label} entityType='label' sourceEntityUrl={releaseUrl!} entityCache={mbLabels} />
-				))}
 				{releaseUrl && (
-					<div class='message'>
+					<LinkWithMusicBrainz
+						entities={allArtists}
+						entityType='artist'
+						sourceEntityUrl={releaseUrl}
+						entityCache={mbArtists}
+					/>
+				)}
+				{releaseUrl && release?.labels && (
+					<LinkWithMusicBrainz
+						entities={release.labels}
+						entityType='label'
+						sourceEntityUrl={releaseUrl!}
+						entityCache={mbLabels}
+					/>
+				)}
+				{releaseUrl && (
+					<div class='action'>
 						<SpriteIcon name='photo-plus' />
 						<div>
 							<p>
@@ -218,14 +223,14 @@ export default defineRoute(async (req, ctx) => {
 					</div>
 				)}
 				{allImages.map((artwork) => <CoverImage artwork={artwork} key={artwork.url} />)}
-				{allRecordings.map((recording) => (
+				{releaseUrl && (
 					<LinkWithMusicBrainz
-						entity={recording}
+						entities={allRecordings}
 						entityType='recording'
-						sourceEntityUrl={releaseUrl!}
+						sourceEntityUrl={releaseUrl}
 						entityCache={mbRecordings}
 					/>
-				))}
+				)}
 			</main>
 		</>
 	);

--- a/server/static/harmony.css
+++ b/server/static/harmony.css
@@ -20,6 +20,9 @@
 	--button-fill: var(--even-fill);
 	--button-focus: var(--odd-fill);
 	--button-border: #dcdcdc;
+	--button-accent-fill: #0066cc;
+	--button-accent-focus: #004d99;
+	--button-accent-text: #ffffff;
 	--link: #0066cc;
 	--link-accent: var(--brand-red);
 	/* Provider brand colors */
@@ -319,9 +322,15 @@ span.entity-links > a:hover {
 	color: var(--link-accent);
 }
 
-/* MessageBox.tsx */
+/* LinkWithMusicBrainz.tsx, actions.tsx */
 
-div.message {
+div.action-group {
+	margin: 1.5em auto;
+}
+
+/* MessageBox.tsx, LinkWithMusicBrainz.tsx, actions.tsx */
+
+div.message, div.action {
 	display: flex;
 	align-items: center;
 	background-color: var(--theme-fill);
@@ -331,7 +340,7 @@ div.message {
 	border-radius: 5px;
 }
 
-div.message > svg.icon {
+div.message > svg.icon, div.action > svg.icon {
 	min-width: fit-content;
 	margin-right: 0.3em;
 }
@@ -341,7 +350,7 @@ div.message span.provider {
 	margin-right: 0.5em;
 }
 
-div.message p, div.message ul {
+div.message p, div.message ul, div.action p, div.action ul {
 	margin: 0;
 }
 
@@ -409,6 +418,23 @@ nav a:link, nav a:visited {
 nav img.icon-logo {
 	height: 2rem;
 	margin-right: 0.3rem;
+}
+
+/* OpenAllLinks.tsx */
+
+button.open-all-links {
+	padding: 0.4em;
+	border-radius: 0.2em;
+	line-height: 0.8em;
+	background-color: var(--button-accent-fill);
+	border: none;
+	color: var(--button-accent-text);
+	font-size: inherit;
+	font-family: inherit;
+}
+
+button.open-all-links:focus, button.open-all-links:hover {
+	background-color: var(--button-accent-focus);
 }
 
 /* ProviderInput.tsx */


### PR DESCRIPTION
Closes: https://github.com/kellnerd/harmony/issues/96

Adds a button to open all links to add external IDs for artists, labels, and recordings. Since opening multiple tabs/windows is blocked by default in most browsers, a warning is shown if the tabs were blocked informing the user that they need to allow pop-ups for the site.

The button to open all links is only shown when more than one link is available. Some margin around the group of links is added then there are multiple links and the button is shown. 

While I've styled the button as a link, it is semantically a button. But at least in from my point of view, I think it fits in better by following the same format as all the other sections on the release actions page.

**Side note:** I wrote a test for `getMusicBrainzEditLink` (which is stashed locally for now) but it is failing due to write permission always being required for the `snaps.db` file. It would be possible to refactor the function further and use dependency injection to get around this. But thought I'd bring it up here before doing so. Thought on that, or suggestions around mocking/stubbing in Deno test?

**Side note 2:** I'm new to the islands architecture and Fresh/Preact, so feel free to give feedback if there are anything that should be done differently. Initially, I ran into an issue related to this where I was trying to send the URL objects to the island which did not work since it is not serializable.

### Button is available for both artist and recording links (as well as for labels) (`/release/actions?release_mbid=53bbe568-4b33-4e93-b93c-f3adc4e15b2d`)

<img width="1356" height="1181" alt="image" src="https://github.com/user-attachments/assets/90705565-8387-4671-b409-a2f8a26151f6" />

### Message informing the user after having clicked the button if the browser blocked tabs from opening

<img width="1352" height="598" alt="image" src="https://github.com/user-attachments/assets/7989583f-548f-4d72-8ebd-b5a294a9a3ec" />


### No change when there is only one link (`/release/actions?release_mbid=7b49ac48-6c32-4831-a7dd-aba21b075299`)

<img width="1363" height="781" alt="image" src="https://github.com/user-attachments/assets/b0e1ad5d-3c9a-4edc-8ca6-992318c06127" />