### PR TITLE
feat: Hide ISRC submission links if ISRCs were already added

### DIFF
--- a/server/components/ISRCSubmission.tsx
+++ b/server/components/ISRCSubmission.tsx
@@ -1,15 +1,68 @@
+import { SpriteIcon } from './SpriteIcon.tsx';
+
 import { musicbrainzTargetServer } from '@/config.ts';
-import type { HarmonyRelease } from '@/harmonizer/types.ts';
+import type { HarmonyRelease, HarmonyTrack, ProviderInfo } from '@/harmonizer/types.ts';
 import { join } from 'std/url/join.ts';
+import type { EntityWithMbid } from '@kellnerd/musicbrainz/api-types';
 
-export function MagicISRC({ release, targetMbid }: { release: HarmonyRelease; targetMbid?: string }) {
-	const allTracks = release.media.flatMap((medium) => medium.tracklist);
+// TODO: incomplete type, expose a suitable type from @kellnerd/musicbrainz?
+export interface EntityWithISRCs extends EntityWithMbid {
+	isrcs?: string[];
+}
+
+function getISRCProvider(release: HarmonyRelease): ProviderInfo | undefined {
 	const isrcSource = release.info.sourceMap?.isrc;
-	const isrcProvider = release.info.providers.find((provider) => provider.name === isrcSource);
-	if (!(allTracks.some((track) => track.isrc) && isrcProvider)) {
-		return null;
-	}
+	if (!isrcSource) return undefined;
+	return release.info.providers.find((provider) => provider.name === isrcSource);
+}
 
+export function ISRCSubmission(
+	{ release, targetMbid, recordingsCache }: {
+		release: HarmonyRelease;
+		targetMbid?: string;
+		recordingsCache?: EntityWithISRCs[];
+	},
+) {
+	const isrcProvider = getISRCProvider(release);
+
+	if (!isrcProvider) return null;
+	const allTracks = release.media.flatMap((medium) => medium.tracklist);
+
+	const needsSubmission = (track: HarmonyTrack): boolean => {
+		// If there's no ISRC, nothing to submit
+		if (!track.isrc) return false;
+
+		const recordingMbid = track.recording?.mbid;
+		// If there's no recording MBID, consider the ISRC as new (needs submission)
+		if (!recordingMbid) return true;
+
+		const mbEntity = recordingsCache?.find((e) => e.id === recordingMbid);
+		// If MB entity is missing or doesn't include the ISRC, it's new
+		return !mbEntity?.isrcs?.includes(track.isrc);
+	};
+
+	const noPendingISRCSubmissions = !allTracks.some(needsSubmission);
+
+	if (noPendingISRCSubmissions) return null;
+
+	return (
+		<div class='action'>
+			<SpriteIcon name='disc' />
+			<p>
+				<MagicISRC allTracks={allTracks} targetMbid={targetMbid} isrcProvider={isrcProvider} />
+				: Submit ISRCs from <a href={isrcProvider.url}>{isrcProvider.name}</a> to MusicBrainz
+			</p>
+		</div>
+	);
+}
+
+function MagicISRC(
+	{ allTracks, targetMbid, isrcProvider }: {
+		allTracks: HarmonyTrack[];
+		targetMbid?: string;
+		isrcProvider: ProviderInfo;
+	},
+) {
 	const query = new URLSearchParams(
 		allTracks.map((track, index) => [`isrc${index + 1}`, track.isrc ?? '']),
 	);


### PR DESCRIPTION
Closes: https://github.com/kellnerd/harmony/issues/125

Hides the ISRC submission section if the recordings already have the ISRCs set.

Some examples to test:

- Already have the ISRCs:
	- `/release/actions?release_mbid=de25aec6-9340-44e5-8584-b3571ca4a7ac`
	- `/release/actions?release_mbid=6698da2f-8c05-4765-8bf4-4fffe0cebaec`
- Missing ISRCs:
	- `/release/actions?musicbrainz=b05b6d2c-8667-470b-b8c0-9581fd2027cb&spotify=70vKZBocKuuWTT08nhVLj8&gtin=886449193363&itunes=&tidal=&region=SE&release_mbid=b05b6d2c-8667-470b-b8c0-9581fd2027cb`
	- `/release/actions?release_mbid=24452979-7205-448d-811f-d03cb649ae3c`
- Missing a lot of ISRCs: `/release/actions?spotify=2Nqpb6pY4bpsfdTfBavVng&gtin=00602445196982&deezer=&itunes=&region=SE&release_mbid=157101a5-f0b7-4d98-b9b2-5ad38a5a4820`