### PR TITLE
Fix Tidal album artist duplication

### DIFF
--- a/providers/Tidal/__snapshots__/mod.test.ts.snap
+++ b/providers/Tidal/__snapshots__/mod.test.ts.snap
@@ -442,17 +442,6 @@ snapshot[`Tidal provider > release lookup > single by two artists (v2 API) 1`] =
 {
   artists: [
     {
-      creditedName: "Bruno Mars",
-      externalIds: [
-        {
-          id: "3658521",
-          provider: "tidal",
-          type: "artist",
-        },
-      ],
-      name: "Bruno Mars",
-    },
-    {
       creditedName: "Lady Gaga",
       externalIds: [
         {
@@ -462,6 +451,17 @@ snapshot[`Tidal provider > release lookup > single by two artists (v2 API) 1`] =
         },
       ],
       name: "Lady Gaga",
+    },
+    {
+      creditedName: "Bruno Mars",
+      externalIds: [
+        {
+          id: "3658521",
+          provider: "tidal",
+          type: "artist",
+        },
+      ],
+      name: "Bruno Mars",
     },
   ],
   copyright: "© 2024 Interscope Records",


### PR DESCRIPTION
This is a fix for the Tidal artist duplication reported in #181

The existing code returned all matching entries from included items, but Tidal API sometimes returns duplicates. Also the included items not necessarily reflect the same order as the relationships.

I haven't seen the latter being a problem, but purely from the code it is a potential issue that is also fixed with this change. And the existing test case seems to have at least at some point had this case, where it contained "Bruno Mars" and "Lady Gaga" as album artist as opposed this other way around (compare https://tidal.com/album/381265361).