### PR TITLE
fix(web): Adjust referrer policy so MB is aware seeding is coming from Harmony

### DIFF
--- a/server/routes/_app.tsx
+++ b/server/routes/_app.tsx
@@ -14,7 +14,7 @@ export default defineApp((_req, ctx) => {
 				<meta charset='utf-8' />
 				<meta name='viewport' content='width=device-width, initial-scale=1.0' />
 				<title>Harmony</title>
-				<meta name='referrer' content='same-origin' />
+				<meta name='referrer' content='strict-origin-when-cross-origin' />
 				<meta name='description' content='Music Metadata Aggregator and MusicBrainz Importer' />
 				<meta property='og:description' content='Music Metadata Aggregator and MusicBrainz Importer' />
 				<meta property='og:image' content={logoUrl.href} />


### PR DESCRIPTION
Since at least when commit b9f174f was present in production, the interstitial MusicBrainz shows for confirmation of seeding data from an external source shows "null" when seeding a release from Harmony. Per @mwiencek, this is likely due to the same-origin referrer policy. By moving to the next-strictest option, we should be able to send the right referrer info to MusicBrainz.

Confirmed that this makes MusicBrainz show the correct source in its interstitial by running a test instance of Harmony from the forked branch and verifying behavior when attempting to seed a release.