### PR TITLE
Fix RTL artists link rendering 

### DIFF
--- a/server/components/LinkedEntity.tsx
+++ b/server/components/LinkedEntity.tsx
@@ -1,5 +1,4 @@
 import { ProviderIcon } from '@/server/components/ProviderIcon.tsx';
-
 import { musicbrainzTargetServer } from '@/config.ts';
 import type { ResolvableEntity } from '@/harmonizer/types.ts';
 import { providers } from '@/providers/mod.ts';
@@ -20,10 +19,12 @@ export function LinkedEntity({ entity, entityType, displayName }: {
 			))}
 			{entity.mbid
 				? (
-<a href={join(musicbrainzTargetServer, entityType, entity.mbid).href}>
-    <ProviderIcon providerName='MusicBrainz' size={18} stroke={1.5} />
-</a>
-{displayName}
+					<>
+						<a href={join(musicbrainzTargetServer, entityType, entity.mbid).href}>
+							<ProviderIcon providerName='MusicBrainz' size={18} stroke={1.5} />
+						</a>
+						{displayName}
+					</>
 				)
 				: displayName}
 		</span>

--- a/server/components/LinkedEntity.tsx
+++ b/server/components/LinkedEntity.tsx
@@ -20,10 +20,10 @@ export function LinkedEntity({ entity, entityType, displayName }: {
 			))}
 			{entity.mbid
 				? (
-					<a href={join(musicbrainzTargetServer, entityType, entity.mbid).href}>
-						<ProviderIcon providerName='MusicBrainz' size={18} stroke={1.5} />
-						{displayName}
-					</a>
+<a href={join(musicbrainzTargetServer, entityType, entity.mbid).href}>
+    <ProviderIcon providerName='MusicBrainz' size={18} stroke={1.5} />
+</a>
+{displayName}
 				)
 				: displayName}
 		</span>


### PR DESCRIPTION
I tested it on my instance the artists icons are rendered properly. 

<img width="322" height="81" alt="image" src="https://github.com/user-attachments/assets/58f9ffed-42db-45ad-8677-c2b8a4965628" />

https://harmony.mybrainz.dev/release?url=https%3A%2F%2Fopen.spotify.com%2Falbum%2F109QLZlDgbLiC1b0P7nJo7&category=preferred

Instead of the current rendering which causes confusion when clicking artist links. 

<img width="333" height="77" alt="image" src="https://github.com/user-attachments/assets/68fade68-b38e-4de6-9ab4-25ca0c792ed5" />


https://harmony.pulsewidth.org.uk/release?url=https%3A%2F%2Ftidal.com%2Falbum%2F529736650&gtin=&region=GB%2CUS%2CDE%2CJP&musicbrainz=&deezer=&itunes=&spotify=&tidal=&qobuz=&beatport=

