### PR TITLE
fix(Qobuz): restore missing GTIN check digits

### DIFF
--- a/providers/Qobuz/mod.test.ts
+++ b/providers/Qobuz/mod.test.ts
@@ -6,7 +6,7 @@ import { assert } from 'std/assert/assert.ts';
 import { afterAll, describe, it } from '@std/testing/bdd';
 import { assertSnapshot } from '@std/testing/snapshot';
 
-import QobuzProvider from './mod.ts';
+import QobuzProvider, { normalizeQobuzGtin } from './mod.ts';
 import { assertEquals } from 'std/assert/assert_equals.ts';
 
 describe('Qobuz provider', () => {
@@ -127,6 +127,16 @@ describe('Qobuz provider', () => {
 			'https://play.qobuz.com/label/97377',
 			'Region should be ignored for label without slug, URL would be invalid',
 		);
+	});
+
+	describe('GTIN normalization', () => {
+		it('appends a missing check digit to legacy 13-digit UPC values', () => {
+			assertEquals(normalizeQobuzGtin('0001589171735'), '00015891717357');
+		});
+
+		it('preserves UPC values which already have a valid check digit', () => {
+			assertEquals(normalizeQobuzGtin('0198884774947'), '0198884774947');
+		});
 	});
 
 	afterAll(() => {

--- a/providers/Qobuz/mod.test.ts
+++ b/providers/Qobuz/mod.test.ts
@@ -130,11 +130,11 @@ describe('Qobuz provider', () => {
 	});
 
 	describe('GTIN normalization', () => {
-		it('appends a missing check digit to legacy 13-digit UPC values', () => {
+		it('appends a missing check digit to invalid 13-digit barcodes, turning them into valid GTIN-14', () => {
 			assertEquals(normalizeQobuzGtin('0001589171735'), '00015891717357');
 		});
 
-		it('preserves UPC values which already have a valid check digit', () => {
+		it('preserves GTIN-13 values which already have a valid check digit', () => {
 			assertEquals(normalizeQobuzGtin('0198884774947'), '0198884774947');
 		});
 	});

--- a/providers/Qobuz/mod.ts
+++ b/providers/Qobuz/mod.ts
@@ -29,6 +29,7 @@ import { ResponseError as SnapResponseError } from 'snap-storage';
 
 const qobuzAppId = getFromEnv('HARMONY_QOBUZ_APP_ID') || '';
 
+/** Appends the missing check digit to invalid 13 digit barcodes from older Qobuz releases. */
 export function normalizeQobuzGtin(upc: string): string {
 	if (isValidGTIN(upc) || !/^\d{13}$/.test(upc)) {
 		return upc;

--- a/providers/Qobuz/mod.ts
+++ b/providers/Qobuz/mod.ts
@@ -5,7 +5,7 @@ import { DurationPrecision, FeatureQuality, FeatureQualityMap } from '@/provider
 import { getFromEnv } from '@/utils/config.ts';
 import { parseHyphenatedDate, PartialDate } from '@/utils/date.ts';
 import { ResponseError } from '@/utils/errors.ts';
-import { isEqualGTIN } from '@/utils/gtin.ts';
+import { checkDigit, isEqualGTIN, isValidGTIN } from '@/utils/gtin.ts';
 import type {
 	ArtistCreditName,
 	Artwork,
@@ -28,6 +28,14 @@ import { availableRegionsAndLanguages, makeQobuzLocale } from './regions.ts';
 import { ResponseError as SnapResponseError } from 'snap-storage';
 
 const qobuzAppId = getFromEnv('HARMONY_QOBUZ_APP_ID') || '';
+
+export function normalizeQobuzGtin(upc: string): string {
+	if (isValidGTIN(upc) || !/^\d{13}$/.test(upc)) {
+		return upc;
+	}
+
+	return `${upc}${checkDigit(`${upc}0`)}`;
+}
 
 export default class QobuzProvider extends MetadataApiProvider {
 	readonly name = 'Qobuz';
@@ -245,7 +253,7 @@ export class QobuzReleaseLookup extends ReleaseApiLookup<QobuzProvider, QobuzAlb
 				types: linkTypes,
 			}],
 			info: this.generateReleaseInfo(),
-			gtin: rawRelease.upc,
+			gtin: normalizeQobuzGtin(rawRelease.upc),
 		};
 	}
 


### PR DESCRIPTION
## Summary

- normalize legacy Qobuz UPC values that contain 13 payload digits but omit the GTIN-14 check digit
- preserve Qobuz identifiers that already have a valid GTIN checksum
- add focused regression coverage for both missing and valid check digits

Qobuz historically used the truncated UPC as the album ID for older releases. When that 13-digit value has an invalid checksum, this appends the calculated check digit before exposing it as the release GTIN. Valid identifiers are returned unchanged.

Addresses #228

## Validation

Run with the repository CI version, Deno 2.4.5:

- `deno fmt --check` (`179` files)
- `deno lint` (`172` files)
- `deno task check`
- `deno test --deny-net --allow-read --allow-env` (`37` passed, `598` steps)
- `deno task build`
- focused `deno test -RE providers/Qobuz/mod.test.ts` (`28` steps)