### PR TITLE
fix(web): show navigation on homepage

### DIFF
--- a/server/routes/_app.tsx
+++ b/server/routes/_app.tsx
@@ -6,7 +6,6 @@ import { defineApp } from 'fresh/server.ts';
 export default defineApp((_req, ctx) => {
 	// OpenGraph image URL must be absolute.
 	const logoUrl = new URL('/harmony-logo.svg', ctx.url);
-	const isLandingPage = ctx.url.pathname === '/';
 
 	return (
 		<html lang='en'>
@@ -24,7 +23,7 @@ export default defineApp((_req, ctx) => {
 				<link rel='manifest' href='/site.webmanifest' />
 			</head>
 			<body>
-				{!isLandingPage && <NavigationBar />}
+				<NavigationBar />
 				<ctx.Component />
 				<Footer />
 			</body>


### PR DESCRIPTION
## Summary

- show the existing navigation bar on the homepage
- make Settings, Release Lookup, and Release Actions available before the first lookup
- keep the current navigation component, links, and styling unchanged

Fixes #230

## Validation

- `deno task ok`
- `deno test -RE` — 38 tests / 617 steps passed
- `deno task build` — 8 routes / 5 islands built
- local SSR smoke: `/` and `/settings` return 200, and `/` contains the `/settings` link
